### PR TITLE
FIXES: several format calls wrongly applied to the result of do instead of the parameter string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 deleteme.aup3
+.DS_Store
 
 
 # Byte-compiled / optimized / DLL files

--- a/src/pyaudacity/__init__.py
+++ b/src/pyaudacity/__init__.py
@@ -97,22 +97,20 @@ def do(command):  # type: (str) -> str
         read_pipe_name = "/tmp/audacity_script_pipe.from." + str(os.getuid())
         eol = "\n"
 
-    if not os.path.exists(write_pipe_name):
-        raise PyAudacityException(
-            write_pipe_name
-            + " does not exist.  Ensure Audacity is running and mod-script-pipe is set to Enabled in the Preferences window."
-        )
-        sys.exit()
+    for pipe in [write_pipe_name, read_pipe_name]:
+        # on macos it sometimes takes more than 0.1ms for the pipe(s) to be ready
+        for wait in [0.0001, 0.1, 0.2, 0.4, 0.8, 1.0]:
+            time.sleep(wait)
+            if os.path.exists(pipe):
+                # sys.stderr.write(f".Waited {wait} seconds\n") # DEBUG/note
+                break
 
-    # For reasons unknown, we need a slight pause after checking for the existence of the read file on Windows:
-    time.sleep(0.0001)
-
-    if not os.path.exists(read_pipe_name):
-        raise PyAudacityException(
-            read_pipe_name
-            + " does not exist.  Ensure Audacity is running and mod-script-pipe is set to Enabled in the Preferences window."
-        )
-        sys.exit()
+        if not pipe:
+            raise PyAudacityException(
+                pipe
+                + " does not exist.  Ensure Audacity is running and mod-script-pipe is set to Enabled in the Preferences window."
+            )
+            sys.exit()
 
     # For reasons unknown, we need a slight pause after checking for the existence of the read file on Windows:
     time.sleep(0.0001)

--- a/src/pyaudacity/__init__.py
+++ b/src/pyaudacity/__init__.py
@@ -2364,7 +2364,7 @@ def wahwah(freq=1.5, phase=0.0, depth=70, resonance=2.5, offset=30, gain=-6.0):
     )
 
 
-def adjustable_fade(type='Up', curve=0.0, units='Percent', gain0=0, gain1=0, preset='None'):
+def adjustable_fade(fade_type='Up', curve=0.0, units='Percent', gain0=0, gain1=0, preset='None'):
     # type: (str, float, str, float, float, str) -> str
     """TODO
 
@@ -2375,7 +2375,7 @@ def adjustable_fade(type='Up', curve=0.0, units='Percent', gain0=0, gain1=0, pre
 
     return do(
         'AdjustableFade: type="{}" curve="{}" units="{}" gain0="{}" gain1="{}" preset="{}"'.format(
-            type, curve, units, gain0, gain1, preset
+            fade_type, curve, units, gain0, gain1, preset
         )
     )
 
@@ -2404,7 +2404,7 @@ def crossfade_clips():
     return do('CrossfadeClips')
 
 
-def crossfade_tracks(type='ConstantGain', curve=0.0, direction='Automatic'):
+def crossfade_tracks(xfade_type='ConstantGain', curve=0.0, direction='Automatic'):
     # type: (str, float, str) -> str
     """TODO
 
@@ -2412,7 +2412,7 @@ def crossfade_tracks(type='ConstantGain', curve=0.0, direction='Automatic'):
     """
 
     # TODO - add param checks
-    return do('CrossfadeTracks: type="{}" curve="{}" direction="{}"'.format(type, curve, direction))
+    return do('CrossfadeTracks: type="{}" curve="{}" direction="{}"'.format(xfade_type, curve, direction))
 
 
 def delay(delay_type='Regular', d_gain=0.0, delay=0.0, pitch_type='PitchTempo', shift=0.0, number=0, constrain='Yes'):
@@ -2440,7 +2440,7 @@ def high_pass_filter(frequency=0.0, roll_off='dB6'):
     return do('High-passFilter: frequency="{}" rolloff="{}"'.format(frequency, roll_off))
 
 
-def limiter(type='SoftLimit', gain_left=0, gain_right=0, limit=0, hold=0, makeup='No'):
+def limiter(limiter_type='SoftLimit', gain_left=0, gain_right=0, limit=0, hold=0, makeup='No'):
     # type: (str, float, float, float, float, str) -> str
     """TODO
 
@@ -2449,7 +2449,7 @@ def limiter(type='SoftLimit', gain_left=0, gain_right=0, limit=0, hold=0, makeup
 
     return do(
         'Limiter: type="{}" gain-L="{}" gain-R="{}" thresh="{}" hold="{}" makeup="{}"'.format(
-            type, gain_left, gain_right, limit, hold, makeup
+            limiter_type, gain_left, gain_right, limit, hold, makeup
         )
     )
 
@@ -3718,20 +3718,20 @@ def set_track():
     raise NotImplementedError
 
 
-def get_info(type='Commands', format='JSON'):
+def get_info(info_type='Commands', format='JSON'):
     # type: (str, str) -> str
     """TODO
 
     Audacity Documentation: Gets information in a list in one of three formats."""
 
-    if type.title() not in ('Commands', 'Menus', 'Preferences', 'Tracks', 'Clips', 'Envelopes', 'Labels', 'Boxes'):
+    if info_type.title() not in ('Commands', 'Menus', 'Preferences', 'Tracks', 'Clips', 'Envelopes', 'Labels', 'Boxes'):
         raise PyAudacityException(
-            'type argument must be one of "Commands", "Menus", "Preferences", "Tracks", "Clips", "Envelopes", "Labels", or "Boxes"'
+            'info_type argument must be one of "Commands", "Menus", "Preferences", "Tracks", "Clips", "Envelopes", "Labels", or "Boxes"'
         )
     if format.title() not in ('JSON', 'LISP', 'Brief'):
         raise PyAudacityException('format argument must be one of "JSON", "LISP", or "Brief"')
 
-    return do('GetInfo: Type="{}" Format="{}"'.format(type, format))
+    return do('GetInfo: Type="{}" Format="{}"'.format(info_type, format))
 
 
 def message(text='Some message'):

--- a/src/pyaudacity/__init__.py
+++ b/src/pyaudacity/__init__.py
@@ -2093,7 +2093,7 @@ def bass_and_treble(bass=0, treble=0, gain=0, link_sliders=False):
 
     # TODO - The documentation shows it as "Link Sliders" but I don't know if the space is intentional or not.
     # There's no way to tell since Audacity's macro system doesn't give errors for bad parameter names.
-    return do('BassAndTreble: Bass="{}" Treble="{}" Gain="{}" LinkSliders="{}"')
+    return do('BassAndTreble: Bass="{}" Treble="{}" Gain="{}" LinkSliders="{}"'.format(bass, treble, gain, link_sliders))
 
 
 def change_pitch(percentage=0.0, use_high_quality_stretching=False):

--- a/src/pyaudacity/__init__.py
+++ b/src/pyaudacity/__init__.py
@@ -2944,7 +2944,16 @@ def vocal_reduction_and_isolation(
     Audacity Documentation: Attempts to remove or isolate center-panned audio from a stereo track. Most "Remove" options in this effect preserve the stereo image.
     """
 
-    # TODO check action
+    actions = "RemoveToMono Remove Isolate IsolateInvert RemoveCenterToMono RemoveCenter IsolateCenter IsolateCenterInvert Analyze".split()
+
+    if action not in actions:
+        raise PyAudacityException(
+            "action must be one of "
+            + ", ".join(actions)
+            + ", but was: '"
+            + action
+            + "'."
+        )
 
     if not isinstance(strength, (float, int)):
         raise PyAudacityException(
@@ -2962,7 +2971,7 @@ def vocal_reduction_and_isolation(
         )
 
     return do(
-        'TODO: strength="{}" low_transition="{}" high_transition="{}"'.format(
+        'VocalReductionAndIsolation: strength="{}" low_transition="{}" high_transition="{}"'.format(
             strength, low_transition, high_transition
         )
     )

--- a/src/pyaudacity/__init__.py
+++ b/src/pyaudacity/__init__.py
@@ -49,13 +49,14 @@ The names are based on the user interface as they appear in Audacity 3.2.5.
 """
 
 
-__version__ = '0.1.2'
+__version__ = "0.1.2"
 
-import os, sys, time
-from pathlib import Path
+import os
+import sys
+import time
 from enum import Enum
-from typing import Union, Optional
-
+from pathlib import Path
+from typing import Optional, Union
 
 # PyAudacity has functions called open() and print(), so save the originals:
 _open = open
@@ -87,18 +88,19 @@ class PyAudacityException(Exception):
 
 
 def do(command):  # type: (str) -> str
-    if sys.platform == 'win32':
-        write_pipe_name = '\\\\.\\pipe\\ToSrvPipe'
-        read_pipe_name = '\\\\.\\pipe\\FromSrvPipe'
-        eol = '\r\n\0'
+    if sys.platform == "win32":
+        write_pipe_name = "\\\\.\\pipe\\ToSrvPipe"
+        read_pipe_name = "\\\\.\\pipe\\FromSrvPipe"
+        eol = "\r\n\0"
     else:
-        write_pipe_name = '/tmp/audacity_script_pipe.to.' + str(os.getuid())
-        read_pipe_name = '/tmp/audacity_script_pipe.from.' + str(os.getuid())
-        eol = '\n'
+        write_pipe_name = "/tmp/audacity_script_pipe.to." + str(os.getuid())
+        read_pipe_name = "/tmp/audacity_script_pipe.from." + str(os.getuid())
+        eol = "\n"
 
     if not os.path.exists(write_pipe_name):
         raise PyAudacityException(
-            write_pipe_name + ' does not exist.  Ensure Audacity is running and mod-script-pipe is set to Enabled in the Preferences window.'
+            write_pipe_name
+            + " does not exist.  Ensure Audacity is running and mod-script-pipe is set to Enabled in the Preferences window."
         )
         sys.exit()
 
@@ -106,24 +108,27 @@ def do(command):  # type: (str) -> str
     time.sleep(0.0001)
 
     if not os.path.exists(read_pipe_name):
-        raise PyAudacityException(read_pipe_name + ' does not exist.  Ensure Audacity is running and mod-script-pipe is set to Enabled in the Preferences window.')
+        raise PyAudacityException(
+            read_pipe_name
+            + " does not exist.  Ensure Audacity is running and mod-script-pipe is set to Enabled in the Preferences window."
+        )
         sys.exit()
 
     # For reasons unknown, we need a slight pause after checking for the existence of the read file on Windows:
     time.sleep(0.0001)
 
-    write_pipe = _open(write_pipe_name, 'w')
+    write_pipe = _open(write_pipe_name, "w")
     read_pipe = _open(read_pipe_name)
 
     write_pipe.write(command + eol)
     write_pipe.flush()
 
-    response = ''
-    line = ''
+    response = ""
+    line = ""
     while True:
         response += line
         line = read_pipe.readline()
-        if line == '\n' and len(response) > 0:
+        if line == "\n" and len(response) > 0:
             break
 
     write_pipe.close()
@@ -134,7 +139,7 @@ def do(command):  # type: (str) -> str
     read_pipe.close()
 
     # sys.stdout.write(response + '\n')  # DEBUG
-    if 'BatchCommand finished: Failed!' in response:
+    if "BatchCommand finished: Failed!" in response:
         raise PyAudacityException(response)
 
     return response
@@ -148,7 +153,7 @@ def new():
     NOTE: The macros issued from pyaudacity always apply to the last Audacity
     window opened. There's no way to pick which Audacity window macros are
     applied to."""
-    return do('New')
+    return do("New")
 
 
 # The open() function uses the OpenProject2 macro, not the Open macro which only opens the Open dialog.
@@ -157,30 +162,38 @@ def open(filename, add_to_history=False):
     """Presents a standard dialog box where you can select either audio files, a list of files (.LOF) or an Audacity Project file to open."""
 
     if not isinstance(filename, (Path, str)):
-        raise PyAudacityException('filename argument must be a Path or str, not' + str(type(add_to_history)))
+        raise PyAudacityException(
+            "filename argument must be a Path or str, not" + str(type(add_to_history))
+        )
 
     if not Path(filename).exists():
-        raise PyAudacityException(str(filename) + ' file not found.')
+        raise PyAudacityException(str(filename) + " file not found.")
     if not isinstance(add_to_history, bool):
-        raise PyAudacityException('add_to_history argument must be a bool, not' + str(type(add_to_history)))
+        raise PyAudacityException(
+            "add_to_history argument must be a bool, not" + str(type(add_to_history))
+        )
 
-    return do('OpenProject2: Filename="{}" AddToHistory="{}"'.format(filename, add_to_history))
+    return do(
+        'OpenProject2: Filename="{}" AddToHistory="{}"'.format(filename, add_to_history)
+    )
 
 
 def close():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Closes the current project window, prompting you to save your work if you have not saved."""
-    return do('Close')
+    Audacity Documentation: Closes the current project window, prompting you to save your work if you have not saved.
+    """
+    return do("Close")
 
 
 def page_setup():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Opens the standard Page Setup dialog box prior to printing."""
-    return do('PageSetup')
+    Audacity Documentation: Opens the standard Page Setup dialog box prior to printing.
+    """
+    return do("PageSetup")
 
 
 def print():
@@ -189,7 +202,7 @@ def print():
 
     Audacity Documentation: Prints all the waveforms in the current project window (and the contents of Label Tracks or other tracks), with the Timeline above. Everything is printed to one page.
     """
-    return do('Print')
+    return do("Print")
 
 
 def exit():
@@ -198,7 +211,7 @@ def exit():
 
     Audacity Documentation: Closes all project windows and exits Audacity. If there are any unsaved changes to your project, Audacity will ask if you want to save them.
     """
-    return do('Exit')
+    return do("Exit")
 
 
 # The save() function uses the SaveProject2 macro, not the Save macro which only opens the Save dialog.
@@ -211,11 +224,19 @@ def save(filename, add_to_history=False, compress=False, allow_overwrite=True):
         os.unlink(Path(filename))
 
     if not isinstance(add_to_history, bool):
-        raise PyAudacityException('add_to_history argument must be a bool, not' + str(type(add_to_history)))
+        raise PyAudacityException(
+            "add_to_history argument must be a bool, not" + str(type(add_to_history))
+        )
     if not isinstance(compress, bool):
-        raise PyAudacityException('compress argument must be a bool, not' + str(type(compress)))
+        raise PyAudacityException(
+            "compress argument must be a bool, not" + str(type(compress))
+        )
 
-    return do('SaveProject2: Filename="{}" AddToHistory="{}" Compress="{}"'.format(filename, add_to_history, compress))
+    return do(
+        'SaveProject2: Filename="{}" AddToHistory="{}" Compress="{}"'.format(
+            filename, add_to_history, compress
+        )
+    )
 
 
 def save_as():
@@ -225,7 +246,7 @@ def save_as():
     Audacity Documentation: Same as save(), but allows you to save a copy of an open project
     to a different name or location."""
 
-    return do('SaveAs')
+    return do("SaveAs")
 
 
 def export_mp3():
@@ -234,7 +255,7 @@ def export_mp3():
 
     Audacity Documentation: Exports to an MP3 file."""
 
-    return do('ExportMp3')
+    return do("ExportMp3")
 
 
 def export_wav():
@@ -243,7 +264,7 @@ def export_wav():
 
     Audacity Documentation: Exports to an WAV file."""
 
-    return do('ExportWav')
+    return do("ExportWav")
 
 
 def export_ogg():
@@ -252,7 +273,7 @@ def export_ogg():
 
     Audacity Documentation: Exports to an OGG file."""
 
-    return do('ExportOgg')
+    return do("ExportOgg")
 
 
 # The export() function uses the Export2 macro, not the Export macro which only opens the Export Audio dialog.
@@ -264,9 +285,11 @@ def export(filename, num_channels=1):
     """
 
     if not os.path.exists(filename):
-        raise PyAudacityException(str(filename) + ' file not found.')
+        raise PyAudacityException(str(filename) + " file not found.")
     if not isinstance(num_channels, int):
-        raise PyAudacityException('num_channels argument must be a int, not' + str(type(num_channels)))
+        raise PyAudacityException(
+            "num_channels argument must be a int, not" + str(type(num_channels))
+        )
 
     return do('Export2: Filename="{}" NumChannels="{}"'.format(filename, num_channels))
 
@@ -275,9 +298,10 @@ def export_sel():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Opens the Export Audio dialog to export the selected audio."""
+    Audacity Documentation: Opens the Export Audio dialog to export the selected audio.
+    """
 
-    return do('ExportSel')
+    return do("ExportSel")
 
 
 def export_labels():
@@ -286,7 +310,7 @@ def export_labels():
 
     Audacity Documentation: Opens the Exports Labels dialog."""
 
-    return do('ExportLabels')
+    return do("ExportLabels")
 
 
 def export_multiple():
@@ -295,7 +319,7 @@ def export_multiple():
 
     Audacity Documentation: Opens the Exports Multiple dialog."""
 
-    return do('ExportMultiple')
+    return do("ExportMultiple")
 
 
 def export_midi():
@@ -304,7 +328,7 @@ def export_midi():
 
     Audacity Documentation: Opens the Export MIDI As dialog."""
 
-    return do('ExportMIDI')
+    return do("ExportMIDI")
 
 
 # The import_audio() function uses the Import2 macro, not the ImportAudio macro which only opens the Import Audio dialog.
@@ -314,12 +338,13 @@ def import_audio(filename):
 
     Audacity Documentation: Imports from a file. The automation command uses a text box to get the file name rather than a normal file-open dialog.
 
-    Note that this function is named import_audio() because import is a Python keyword."""
+    Note that this function is named import_audio() because import is a Python keyword.
+    """
 
     if not os.path.exists(filename):
-        raise PyAudacityException(str(filename) + ' file not found.')
+        raise PyAudacityException(str(filename) + " file not found.")
 
-    return do('ImportAudio')
+    return do("ImportAudio")
 
 
 def import_labels():
@@ -328,7 +353,7 @@ def import_labels():
 
     Audacity Documentation: Open the Import Labels dialog."""
 
-    return do('ImportLabels')
+    return do("ImportLabels")
 
 
 def import_midi():
@@ -337,7 +362,7 @@ def import_midi():
 
     Audacity Documentation: Opens the Import MIDI dialog."""
 
-    return do('ImportMIDI')
+    return do("ImportMIDI")
 
 
 def import_raw():
@@ -346,7 +371,7 @@ def import_raw():
 
     Audacity Documentation: Opens the Import Raw dialog."""
 
-    return do('ImportRaw')
+    return do("ImportRaw")
 
 
 def undo():
@@ -355,7 +380,7 @@ def undo():
 
     Audacity Documentation: Undoes the most recent editing action."""
 
-    return do('Undo')
+    return do("Undo")
 
 
 def redo():
@@ -364,7 +389,7 @@ def redo():
 
     Audacity Documentation: Redoes the most recently undone editing action."""
 
-    return do('Redo')
+    return do("Redo")
 
 
 def cut():
@@ -374,7 +399,7 @@ def cut():
     Audacity Documentation: Removes the selected audio data and/or labels and places these on the Audacity clipboard. By default, any audio or labels to right of the selection are shifted to the left.
     """
 
-    return do('Cut')
+    return do("Cut")
 
 
 def delete():
@@ -383,7 +408,7 @@ def delete():
 
     Audacity Documentation: Removes the selected audio data and/or labels without copying these to the Audacity clipboard. By default, any audio or labels to right of the selection are shifted to the left.
     """
-    return do('Delete')
+    return do("Delete")
 
 
 def copy():
@@ -392,7 +417,7 @@ def copy():
 
     Audacity Documentation: Copies the selected audio data to the Audacity clipboard without removing it from the project.
     """
-    return do('Copy')
+    return do("Copy")
 
 
 def paste():
@@ -401,15 +426,16 @@ def paste():
 
     Audacity Documentation: Inserts whatever is on the Audacity clipboard at the position of the selection cursor in the project, replacing whatever audio data is currently selected, if any.
     """
-    return do('Paste')
+    return do("Paste")
 
 
 def duplicate():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Creates a new track containing only the current selection as a new clip."""
-    return do('Duplicate')
+    Audacity Documentation: Creates a new track containing only the current selection as a new clip.
+    """
+    return do("Duplicate")
 
 
 def edit_meta_data():
@@ -417,7 +443,7 @@ def edit_meta_data():
     """TODO
 
     Audacity Documentation: Open the Edit Metadata Tags dialog."""
-    return do('EditMetaData')
+    return do("EditMetaData")
 
 
 def preferences():
@@ -425,15 +451,16 @@ def preferences():
     """TODO
 
     Audacity Documentation: Open the Preferences dialog."""
-    return do('Preferences')
+    return do("Preferences")
 
 
 def split_cut():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Same as Cut, but none of the audio data or labels to right of the selection are shifted."""
-    return do('SplitCut')
+    Audacity Documentation: Same as Cut, but none of the audio data or labels to right of the selection are shifted.
+    """
+    return do("SplitCut")
 
 
 def split_delete():
@@ -442,7 +469,7 @@ def split_delete():
 
     Audacity Documentation: Same as Delete, but none of the audio data or labels to right of the selection are shifted.
     """
-    return do('SplitDelete')
+    return do("SplitDelete")
 
 
 def silence():
@@ -451,7 +478,7 @@ def silence():
 
     Audacity Documentation: Replaces the currently selected audio with absolute silence. Does not affect label tracks.
     """
-    return do('Silence')
+    return do("Silence")
 
 
 def trim():
@@ -460,7 +487,7 @@ def trim():
 
     Audacity Documentation: Deletes all audio but the selection. If there are other separate clips in the same track these are not removed or shifted unless trimming the entire length of a clip or clips. Does not affect label tracks.
     """
-    return do('Trim')
+    return do("Trim")
 
 
 def split():
@@ -469,7 +496,7 @@ def split():
 
     Audacity Documentation: Splits the current clip into two clips at the cursor point, or into three clips at the selection boundaries.
     """
-    return do('Split')
+    return do("Split")
 
 
 def split_new():
@@ -478,7 +505,7 @@ def split_new():
 
     Audacity Documentation: Does a Split Cut on the current selection in the current track, then creates a new track and pastes the selection into the new track.
     """
-    return do('SplitNew')
+    return do("SplitNew")
 
 
 def join():
@@ -487,7 +514,7 @@ def join():
 
     Audacity Documentation: If you select an area that overlaps one or more clips, they are all joined into one large clip. Regions in-between clips become silence.
     """
-    return do('Join')
+    return do("Join")
 
 
 def disjoin():
@@ -496,7 +523,7 @@ def disjoin():
 
     Audacity Documentation: In a selection region that includes absolute silences, creates individual non-silent clips between the regions of silence. The silence becomes blank space between the clips.
     """
-    return do('Disjoin')
+    return do("Disjoin")
 
 
 def edit_labels():
@@ -504,23 +531,25 @@ def edit_labels():
     """TODO
 
     Audacity Documentation: Open the Edit Labels dialog."""
-    return do('EditLabels')
+    return do("EditLabels")
 
 
 def add_label():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Creates a new, empty label at the cursor or at the selection region."""
-    return do('AddLabel')
+    Audacity Documentation: Creates a new, empty label at the cursor or at the selection region.
+    """
+    return do("AddLabel")
 
 
 def add_label_playing():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Creates a new, empty label at the current playback or recording position."""
-    return do('AddLabelPlaying')
+    Audacity Documentation: Creates a new, empty label at the current playback or recording position.
+    """
+    return do("AddLabelPlaying")
 
 
 def paste_new_label():
@@ -529,15 +558,16 @@ def paste_new_label():
 
     Audacity Documentation: Pastes the text on the Audacity clipboard at the cursor position in the currently selected label track. If there is no selection in the label track a point label is created. If a region is selected in the label track a region label is created. If no label track is selected one is created, and a new label is created.
     """
-    return do('PasteNewLabel')
+    return do("PasteNewLabel")
 
 
 def type_to_create_label():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Creates a new label and allows the user to type to fill it out."""
-    return do('TypeToCreateLabel')
+    Audacity Documentation: Creates a new label and allows the user to type to fill it out.
+    """
+    return do("TypeToCreateLabel")
 
 
 def cut_labels():
@@ -546,7 +576,7 @@ def cut_labels():
 
     Audacity Documentation: Removes the selected labels and places these on the Audacity clipboard. By default, any audio or labels to right of the selection are shifted to the left.
     """
-    return do('CutLabels')
+    return do("CutLabels")
 
 
 def delete_labels():
@@ -555,7 +585,7 @@ def delete_labels():
 
     Audacity Documentation: Removes the selected labels without copying these to the Audacity clipboard. By default, any audio or labels to right of the selection are shifted to the left.
     """
-    return do('DeleteLabels')
+    return do("DeleteLabels")
 
 
 def split_cut_labels():
@@ -564,7 +594,7 @@ def split_cut_labels():
 
     Audacity Documentation: Removes the selected labels and places these on the Audacity clipboard, but none of the audio data or labels to right of the selection are shifted.
     """
-    return do('SplitCutLabels')
+    return do("SplitCutLabels")
 
 
 def split_delete_labels():
@@ -573,7 +603,7 @@ def split_delete_labels():
 
     Audacity Documentation: Removes the selected labels without copying these to the Audacity clipboard, but none of the audio data or labels to right of the selection are shifted.
     """
-    return do('SplitDeleteLabels')
+    return do("SplitDeleteLabels")
 
 
 def copy_labels():
@@ -582,7 +612,7 @@ def copy_labels():
 
     Audacity Documentation: Copies the selected labels to the Audacity clipboard without removing it from the project.
     """
-    return do('CopyLabels')
+    return do("CopyLabels")
 
 
 def split_labels():
@@ -591,7 +621,7 @@ def split_labels():
 
     Audacity Documentation: Splits the current labeled audio regions into two regions at the cursor point, or into three regions at the selection boundaries.
     """
-    return do('SplitLabels')
+    return do("SplitLabels")
 
 
 def join_labels():
@@ -600,15 +630,16 @@ def join_labels():
 
     Audacity Documentation: If you select an area that overlaps one or more labeled audio regions, they are all joined into one large clip.
     """
-    return do('JoinLabels')
+    return do("JoinLabels")
 
 
 def disjoin_labels():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Same as the Detach at Silences command, but operates on labeled audio regions."""
-    return do('DisjoinLabels')
+    Audacity Documentation: Same as the Detach at Silences command, but operates on labeled audio regions.
+    """
+    return do("DisjoinLabels")
 
 
 def select_all():
@@ -616,7 +647,7 @@ def select_all():
     """TODO
 
     Audacity Documentation: Selects all of the audio in all of the tracks."""
-    return do('SelectAll')
+    return do("SelectAll")
 
 
 def select_none():
@@ -624,23 +655,25 @@ def select_none():
     """TODO
 
     Audacity Documentation: Deselects all of the audio in all of the tracks."""
-    return do('SelectNone')
+    return do("SelectNone")
 
 
 def sel_cursor_stored_cursor():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Selects from the position of the cursor to the previously stored cursor position."""
-    return do('SelCursorStoredCursor')
+    Audacity Documentation: Selects from the position of the cursor to the previously stored cursor position.
+    """
+    return do("SelCursorStoredCursor")
 
 
 def store_cursor_position():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Stores the current cursor position for use in a later selection."""
-    return do('StoreCursorPosition')
+    Audacity Documentation: Stores the current cursor position for use in a later selection.
+    """
+    return do("StoreCursorPosition")
 
 
 def zero_cross():
@@ -649,15 +682,16 @@ def zero_cross():
 
     Audacity Documentation: Moves the edges of a selection region (or the cursor position) slightly so they are at a rising zero crossing point.
     """
-    return do('ZeroCross')
+    return do("ZeroCross")
 
 
 def sel_all_tracks():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Extends the current selection up and/or down into all tracks in the project."""
-    return do('SelAllTracks')
+    Audacity Documentation: Extends the current selection up and/or down into all tracks in the project.
+    """
+    return do("SelAllTracks")
 
 
 def sel_sync_lock_tracks():
@@ -666,7 +700,7 @@ def sel_sync_lock_tracks():
 
     Audacity Documentation: Extends the current selection up and/or down into all sync-locked tracks in the currently selected track group.
     """
-    return do('SelSyncLockTracks')
+    return do("SelSyncLockTracks")
 
 
 def left_at_playback_position():
@@ -675,7 +709,7 @@ def left_at_playback_position():
 
     Audacity Documentation: When Audacity is playing, recording or paused, sets the left boundary of a potential selection by moving the cursor to the current position of the green playback cursor (or red recording cursor). Otherwise, opens the "Set Left Selection Boundary" dialog for adjusting the time position of the left-hand selection boundary. If there is no selection, moving the time digits backwards creates a selection ending at the former cursor position, and moving the time digits forwards provides a way to move the cursor forwards to an exact point.
     """
-    return do('Left at Playback Position')
+    return do("Left at Playback Position")
 
 
 def right_at_playback_position():
@@ -684,7 +718,7 @@ def right_at_playback_position():
 
     Audacity Documentation: When Audacity is playing, recording or paused, sets the right boundary of the selection, thus drawing the selection from the cursor position to the current position of the green playback cursor (or red recording cursor). Otherwise, opens the "Set Right Selection Boundary" dialog for adjusting the time position of the right-hand selection boundary. If there is no selection, moving the time digits forwards creates a selection starting at the former cursor position, and moving the time digits backwards provides a way to move the cursor backwards to an exact point.
     """
-    return do('Right at Playback Position')
+    return do("Right at Playback Position")
 
 
 def sel_track_start_to_cursor():
@@ -693,7 +727,7 @@ def sel_track_start_to_cursor():
 
     Audacity Documentation: Selects a region in the selected track(s) from the start of the track to the cursor position.
     """
-    return do('SelTrackStartToCursor')
+    return do("SelTrackStartToCursor")
 
 
 def sel_cursor_to_track_end():
@@ -702,7 +736,7 @@ def sel_cursor_to_track_end():
 
     Audacity Documentation: Selects a region in the selected track(s) from the cursor position to the end of the track.
     """
-    return do('SelCursorToTrackEnd')
+    return do("SelCursorToTrackEnd")
 
 
 def sel_track_start_to_end():
@@ -711,7 +745,7 @@ def sel_track_start_to_end():
 
     Audacity Documentation: Selects a region in the selected track(s) from the start of the track to the end of the track.
     """
-    return do('SelTrackStartToEnd')
+    return do("SelTrackStartToEnd")
 
 
 def sel_save():
@@ -719,15 +753,16 @@ def sel_save():
     """TODO
 
     Audacity Documentation: Stores the end points of a selection for later reuse."""
-    return do('SelSave')
+    return do("SelSave")
 
 
 def sel_restore():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Retrieves the end points of a previously stored selection."""
-    return do('SelRestore')
+    Audacity Documentation: Retrieves the end points of a previously stored selection.
+    """
+    return do("SelRestore")
 
 
 def toggle_spectral_selection():
@@ -736,7 +771,7 @@ def toggle_spectral_selection():
 
     Audacity Documentation: Changes between selecting a time range and selecting the last selected spectral selection in that time range. This command toggles the spectral selection even if not in Spectrogram view, but you must be in Spectrogram view to use the spectral selection in one of the Spectral edit effects.
     """
-    return do('ToggleSpectralSelection')
+    return do("ToggleSpectralSelection")
 
 
 def next_higher_peak_frequency():
@@ -745,7 +780,7 @@ def next_higher_peak_frequency():
 
     Audacity Documentation: When in Spectrogram view, snaps the center frequency to the next higher frequency peak, moving the spectral selection upwards.
     """
-    return do('NextHigherPeakFrequency')
+    return do("NextHigherPeakFrequency")
 
 
 def next_lower_peak_frequency():
@@ -754,7 +789,7 @@ def next_lower_peak_frequency():
 
     Audacity Documentation: When in Spectrogram views snaps the center frequency to the next lower frequency peak, moving the spectral selection downwards.
     """
-    return do('NextLowerPeakFrequency')
+    return do("NextLowerPeakFrequency")
 
 
 def sel_prev_clip_boundary_to_cursor():
@@ -763,15 +798,16 @@ def sel_prev_clip_boundary_to_cursor():
 
     Audacity Documentation: Selects from the current cursor position back to the right-hand edge of the previous clip.
     """
-    return do('SelPrevClipBoundaryToCursor')
+    return do("SelPrevClipBoundaryToCursor")
 
 
 def sel_cursor_to_next_clip_boundary():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Selects from the current cursor position forward to the left-hand edge of the next clip."""
-    return do('SelCursorToNextClipBoundary')
+    Audacity Documentation: Selects from the current cursor position forward to the left-hand edge of the next clip.
+    """
+    return do("SelCursorToNextClipBoundary")
 
 
 def sel_prev_clip():
@@ -779,7 +815,7 @@ def sel_prev_clip():
     """TODO
 
     Audacity Documentation: Moves the selection to the previous clip."""
-    return do('SelPrevClip')
+    return do("SelPrevClip")
 
 
 def sel_next_clip():
@@ -787,7 +823,7 @@ def sel_next_clip():
     """TODO
 
     Audacity Documentation: Moves the selection to the next clip."""
-    return do('SelNextClip')
+    return do("SelNextClip")
 
 
 def undo_history():
@@ -796,7 +832,7 @@ def undo_history():
 
     Audacity Documentation: Brings up the History window which can then be left open while using Audacity normally. History lists all undoable actions performed in the current project, including importing.
     """
-    return do('UndoHistory')
+    return do("UndoHistory")
 
 
 def karaoke():
@@ -805,7 +841,7 @@ def karaoke():
 
     Audacity Documentation: Brings up the Karaoke window, which displays the labels in a "bouncing ball" scrolling display.
     """
-    return do('Karaoke')
+    return do("Karaoke")
 
 
 def mixer_board():
@@ -814,7 +850,7 @@ def mixer_board():
 
     Audacity Documentation: Mixer Board is an alternative view to the audio tracks in the main tracks window. Analogous to a hardware mixer board, each audio track is displayed in a Track Strip.
     """
-    return do('MixerBoard')
+    return do("MixerBoard")
 
 
 def show_extra_menus():
@@ -822,15 +858,16 @@ def show_extra_menus():
     """TODO
 
     Audacity Documentation: Shows extra menus with many extra less-used commands."""
-    return do('ShowExtraMenus')
+    return do("ShowExtraMenus")
 
 
 def show_clipping():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Option to show or not show audio that is too loud (in red) on the wave form."""
-    return do('ShowClipping')
+    Audacity Documentation: Option to show or not show audio that is too loud (in red) on the wave form.
+    """
+    return do("ShowClipping")
 
 
 def zoom_in():
@@ -839,79 +876,88 @@ def zoom_in():
 
     Audacity Documentation: Zooms in on the horizontal axis of the audio displaying more detail over a shorter length of time.
     """
-    return do('ZoomIn')
+    return do("ZoomIn")
 
 
 def zoom_normal():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Zooms to the default view which displays about one inch per second."""
-    return do('ZoomNormal')
+    Audacity Documentation: Zooms to the default view which displays about one inch per second.
+    """
+    return do("ZoomNormal")
 
 
 def zoom_out():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Zooms out displaying less detail over a greater length of time."""
-    return do('ZoomOut')
+    Audacity Documentation: Zooms out displaying less detail over a greater length of time.
+    """
+    return do("ZoomOut")
 
 
 def zoom_sel():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Zooms in or out so that the selected audio fills the width of the window."""
-    return do('ZoomSel')
+    Audacity Documentation: Zooms in or out so that the selected audio fills the width of the window.
+    """
+    return do("ZoomSel")
 
 
 def zoom_toggle():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Changes the zoom back and forth between two preset levels."""
-    return do('ZoomToggle')
+    Audacity Documentation: Changes the zoom back and forth between two preset levels.
+    """
+    return do("ZoomToggle")
 
 
 def advanced_v_zoom():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Enable for left-click gestures in the vertical scale to control zooming."""
-    return do('AdvancedVZoom')
+    Audacity Documentation: Enable for left-click gestures in the vertical scale to control zooming.
+    """
+    return do("AdvancedVZoom")
 
 
 def fit_in_window():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Zooms out until the entire project just fits in the window."""
-    return do('FitInWindow')
+    Audacity Documentation: Zooms out until the entire project just fits in the window.
+    """
+    return do("FitInWindow")
 
 
 def fit_v():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Adjusts the height of all the tracks until they fit in the project window."""
-    return do('FitV')
+    Audacity Documentation: Adjusts the height of all the tracks until they fit in the project window.
+    """
+    return do("FitV")
 
 
 def collapse_all_tracks():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Collapses all tracks to take up the minimum amount of space."""
-    return do('CollapseAllTracks')
+    Audacity Documentation: Collapses all tracks to take up the minimum amount of space.
+    """
+    return do("CollapseAllTracks")
 
 
 def expand_all_tracks():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Expands all collapsed tracks to their original size before the last collapse."""
-    return do('ExpandAllTracks')
+    Audacity Documentation: Expands all collapsed tracks to their original size before the last collapse.
+    """
+    return do("ExpandAllTracks")
 
 
 def skip_sel_start():
@@ -920,7 +966,7 @@ def skip_sel_start():
 
     Audacity Documentation: When there is a selection, moves the cursor to the start of the selection and removes the selection.
     """
-    return do('SkipSelStart')
+    return do("SkipSelStart")
 
 
 def skip_sel_end():
@@ -929,7 +975,7 @@ def skip_sel_end():
 
     Audacity Documentation: When there is a selection, moves the cursor to the end of the selection and removes the selection.
     """
-    return do('SkipSelEnd')
+    return do("SkipSelEnd")
 
 
 def reset_toolbars():
@@ -938,7 +984,7 @@ def reset_toolbars():
 
     Audacity Documentation: Using this command positions all toolbars in default location and size as they were when Audacity was first installed.
     """
-    return do('ResetToolbars')
+    return do("ResetToolbars")
 
 
 def show_transport_t_b():
@@ -947,7 +993,7 @@ def show_transport_t_b():
 
     Audacity Documentation: Controls playback and recording and skips to start or end of project when neither playing or recording.
     """
-    return do('ShowTransportTB')
+    return do("ShowTransportTB")
 
 
 def show_tools_t_b():
@@ -956,15 +1002,16 @@ def show_tools_t_b():
 
     Audacity Documentation: Chooses various tools for selection, volume adjustment, zooming and time-shifting of audio.
     """
-    return do('ShowToolsTB')
+    return do("ShowToolsTB")
 
 
 def show_record_meter_t_b():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Displays recording levels and toggles input monitoring when not recording."""
-    return do('ShowRecordMeterTB')
+    Audacity Documentation: Displays recording levels and toggles input monitoring when not recording.
+    """
+    return do("ShowRecordMeterTB")
 
 
 def show_play_meter_t_b():
@@ -972,7 +1019,7 @@ def show_play_meter_t_b():
     """TODO
 
     Audacity Documentation: Displays playback levels."""
-    return do('ShowPlayMeterTB')
+    return do("ShowPlayMeterTB")
 
 
 def show_mixer_t_b():
@@ -981,23 +1028,25 @@ def show_mixer_t_b():
 
     Audacity Documentation: Adjusts the recording and playback volumes of the devices currently selected in Device Toolbar.
     """
-    return do('ShowMixerTB')
+    return do("ShowMixerTB")
 
 
 def show_edit_t_b():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Cut, copy, paste, trim audio, silence audio, undo, redo, zoom tools."""
-    return do('ShowEditTB')
+    Audacity Documentation: Cut, copy, paste, trim audio, silence audio, undo, redo, zoom tools.
+    """
+    return do("ShowEditTB")
 
 
 def show_transcription_t_b():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Plays audio at a slower or faster speed than normal, affecting pitch."""
-    return do('ShowTranscriptionTB')
+    Audacity Documentation: Plays audio at a slower or faster speed than normal, affecting pitch.
+    """
+    return do("ShowTranscriptionTB")
 
 
 def show_scrubbing_t_b():
@@ -1006,15 +1055,16 @@ def show_scrubbing_t_b():
 
     Audacity Documentation: Controls playback and recording and skips to start or end of project when neither playing or recording.
     """
-    return do('ShowScrubbingTB')
+    return do("ShowScrubbingTB")
 
 
 def show_device_t_b():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Selects audio host, recording device, number of recording channels and playback device."""
-    return do('ShowDeviceTB')
+    Audacity Documentation: Selects audio host, recording device, number of recording channels and playback device.
+    """
+    return do("ShowDeviceTB")
 
 
 def show_selection_t_b():
@@ -1023,7 +1073,7 @@ def show_selection_t_b():
 
     Audacity Documentation: Controls the sample rate of the project, snapping to the selection format and adjusts cursor and region position by keyboard input.
     """
-    return do('ShowSelectionTB')
+    return do("ShowSelectionTB")
 
 
 def show_spectral_selection_t_b():
@@ -1032,7 +1082,7 @@ def show_spectral_selection_t_b():
 
     Audacity Documentation: Displays and lets you adjust the current spectral (frequency) selection without having to be in Spectrogram view.
     """
-    return do('ShowSpectralSelectionTB')
+    return do("ShowSpectralSelectionTB")
 
 
 def rescan_devices():
@@ -1041,7 +1091,7 @@ def rescan_devices():
 
     Audacity Documentation: Rescan for audio devices connected to your computer, and update the playback and recording dropdown menus in Device Toolbar.
     """
-    return do('RescanDevices')
+    return do("RescanDevices")
 
 
 def play_stop():
@@ -1050,7 +1100,7 @@ def play_stop():
 
     Audacity Documentation: Starts and stops playback or stops a recording (stopping does not change the restart position). Therefore using any play or record command after stopping with "Play/Stop" will start playback or recording from the same Timeline position it last started from. You can also assign separate shortcuts for Play and Stop.
     """
-    return do('PlayStop')
+    return do("PlayStop")
 
 
 def play_stop_select():
@@ -1059,23 +1109,25 @@ def play_stop_select():
 
     Audacity Documentation: Starts playback like "Play/Stop", but stopping playback sets the restart position to the stop point. When stopped, this command is the same as "Play/Stop". When playing, this command stops playback and moves the cursor (or the start of the selection) to the position where playback stopped.
     """
-    return do('PlayStopSelect')
+    return do("PlayStopSelect")
 
 
 def pause():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Temporarily pauses playing or recording without losing your place."""
-    return do('Pause')
+    Audacity Documentation: Temporarily pauses playing or recording without losing your place.
+    """
+    return do("Pause")
 
 
 def record1st_choice():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Starts recording at the end of the currently selected track(s)."""
-    return do('Record1stChoice')
+    Audacity Documentation: Starts recording at the end of the currently selected track(s).
+    """
+    return do("Record1stChoice")
 
 
 def record2nd_choice():
@@ -1084,7 +1136,7 @@ def record2nd_choice():
 
     Audacity Documentation: Recording begins on a new track at either the current cursor location or at the beginning of the current selection.
     """
-    return do('Record2ndChoice')
+    return do("Record2ndChoice")
 
 
 def timer_record():
@@ -1092,15 +1144,16 @@ def timer_record():
     """TODO
 
     Audacity Documentation: Brings up the Timer Record dialog."""
-    return do('TimerRecord')
+    return do("TimerRecord")
 
 
 def punch_and_roll():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Re-record over audio, with a pre-roll of audio that comes before."""
-    return do('PunchAndRoll')
+    Audacity Documentation: Re-record over audio, with a pre-roll of audio that comes before.
+    """
+    return do("PunchAndRoll")
 
 
 def scrub():
@@ -1109,7 +1162,7 @@ def scrub():
 
     Audacity Documentation: Scrubbing is the action of moving the mouse pointer right or left so as to adjust the position, speed or direction of playback, listening to the audio at the same time.
     """
-    return do('Scrub')
+    return do("Scrub")
 
 
 def seek():
@@ -1118,15 +1171,16 @@ def seek():
 
     Audacity Documentation: Seeking is similar to Scrubbing except that it is playback with skips, similar to using the seek button on a CD player.
     """
-    return do('Seek')
+    return do("Seek")
 
 
 def toggle_scrub_ruler():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Shows (or hides) the scrub ruler, which is just below the timeline."""
-    return do('ToggleScrubRuler')
+    Audacity Documentation: Shows (or hides) the scrub ruler, which is just below the timeline.
+    """
+    return do("ToggleScrubRuler")
 
 
 def curs_sel_start():
@@ -1135,7 +1189,7 @@ def curs_sel_start():
 
     Audacity Documentation: Moves the left edge of the current selection to the center of the screen, without changing the zoom level.
     """
-    return do('CursSelStart')
+    return do("CursSelStart")
 
 
 def curs_sel_end():
@@ -1144,7 +1198,7 @@ def curs_sel_end():
 
     Audacity Documentation: Moves the right edge of the current selection to the center of the screen, without changing the zoom level.
     """
-    return do('CursSelEnd')
+    return do("CursSelEnd")
 
 
 def curs_track_start():
@@ -1152,7 +1206,7 @@ def curs_track_start():
     """TODO
 
     Audacity Documentation: Moves the cursor to the start of the selected track."""
-    return do('CursTrackStart')
+    return do("CursTrackStart")
 
 
 def curs_track_end():
@@ -1160,23 +1214,25 @@ def curs_track_end():
     """TODO
 
     Audacity Documentation: Moves the cursor to the end of the selected track."""
-    return do('CursTrackEnd')
+    return do("CursTrackEnd")
 
 
 def curs_prev_clip_boundary():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Moves the cursor position back to the right-hand edge of the previous clip."""
-    return do('CursPrevClipBoundary')
+    Audacity Documentation: Moves the cursor position back to the right-hand edge of the previous clip.
+    """
+    return do("CursPrevClipBoundary")
 
 
 def curs_next_clip_boundary():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Moves the cursor position forward to the left-hand edge of the next clip."""
-    return do('CursNextClipBoundary')
+    Audacity Documentation: Moves the cursor position forward to the left-hand edge of the next clip.
+    """
+    return do("CursNextClipBoundary")
 
 
 def curs_project_start():
@@ -1184,7 +1240,7 @@ def curs_project_start():
     """TODO
 
     Audacity Documentation: Moves the cursor to the beginning of the project."""
-    return do('CursProjectStart')
+    return do("CursProjectStart")
 
 
 def curs_project_end():
@@ -1192,15 +1248,16 @@ def curs_project_end():
     """TODO
 
     Audacity Documentation: Moves the cursor to the end of the project."""
-    return do('CursProjectEnd')
+    return do("CursProjectEnd")
 
 
 def sound_activation_level():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Sets the activation level above which Sound Activated Recording will record."""
-    return do('SoundActivationLevel')
+    Audacity Documentation: Sets the activation level above which Sound Activated Recording will record.
+    """
+    return do("SoundActivationLevel")
 
 
 def sound_activation():
@@ -1208,7 +1265,7 @@ def sound_activation():
     """TODO
 
     Audacity Documentation: Toggles on and off the Sound Activated Recording option."""
-    return do('SoundActivation')
+    return do("SoundActivation")
 
 
 def pinned_head():
@@ -1217,7 +1274,7 @@ def pinned_head():
 
     Audacity Documentation: You can change Audacity to play and record with a fixed head pinned to the Timeline. You can adjust the position of the fixed head by dragging it.
     """
-    return do('PinnedHead')
+    return do("PinnedHead")
 
 
 def overdub():
@@ -1225,7 +1282,7 @@ def overdub():
     """TODO
 
     Audacity Documentation: Toggles on and off the Overdub option."""
-    return do('Overdub')
+    return do("Overdub")
 
 
 def s_w_playthrough():
@@ -1233,15 +1290,16 @@ def s_w_playthrough():
     """TODO
 
     Audacity Documentation: Toggles on and off the Software Playthrough option."""
-    return do('SWPlaythrough')
+    return do("SWPlaythrough")
 
 
 def resample():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Allows you to resample the selected track(s) to a new sample rate for use in the project."""
-    return do('Resample')
+    Audacity Documentation: Allows you to resample the selected track(s) to a new sample rate for use in the project.
+    """
+    return do("Resample")
 
 
 def remove_tracks():
@@ -1250,7 +1308,7 @@ def remove_tracks():
 
     Audacity Documentation: Removes the selected track(s) from the project. Even if only part of a track is selected, the entire track is removed.
     """
-    return do('RemoveTracks')
+    return do("RemoveTracks")
 
 
 def sync_lock():
@@ -1259,7 +1317,7 @@ def sync_lock():
 
     Audacity Documentation: Ensures that length changes occurring anywhere in a defined group of tracks also take place in all audio or label tracks in that group.
     """
-    return do('SyncLock')
+    return do("SyncLock")
 
 
 def new_mono_track():
@@ -1267,7 +1325,7 @@ def new_mono_track():
     """TODO
 
     Audacity Documentation: Creates a new empty mono audio track."""
-    return do('NewMonoTrack')
+    return do("NewMonoTrack")
 
 
 def new_stereo_track():
@@ -1275,7 +1333,7 @@ def new_stereo_track():
     """TODO
 
     Audacity Documentation: Adds an empty stereo track to the project."""
-    return do('NewStereoTrack')
+    return do("NewStereoTrack")
 
 
 def new_label_track():
@@ -1283,7 +1341,7 @@ def new_label_track():
     """TODO
 
     Audacity Documentation: Adds an empty label track to the project."""
-    return do('NewLabelTrack')
+    return do("NewLabelTrack")
 
 
 def new_time_track():
@@ -1292,7 +1350,7 @@ def new_time_track():
 
     Audacity Documentation: Adds an empty time track to the project. Time tracks are used to speed up and slow down audio.
     """
-    return do('NewTimeTrack')
+    return do("NewTimeTrack")
 
 
 def stereo_to_mono():
@@ -1301,7 +1359,7 @@ def stereo_to_mono():
 
     Audacity Documentation: Converts the selected stereo track(s) into the same number of mono tracks, combining left and right channels equally by averaging the volume of both channels.
     """
-    return do('Stereo to Mono')
+    return do("Stereo to Mono")
 
 
 def mix_and_render():
@@ -1310,7 +1368,7 @@ def mix_and_render():
 
     Audacity Documentation: Mixes down all selected tracks to a single mono or stereo track, rendering to the waveform all real-time transformations that had been applied (such as track gain, panning, amplitude envelopes or a change in project rate).
     """
-    return do('MixAndRender')
+    return do("MixAndRender")
 
 
 def mix_and_render_to_new_track():
@@ -1319,7 +1377,7 @@ def mix_and_render_to_new_track():
 
     Audacity Documentation: Same as Tracks > Mix and Render except that the original tracks are preserved rather than being replaced by the resulting "Mix" track.
     """
-    return do('MixAndRenderToNewTrack')
+    return do("MixAndRenderToNewTrack")
 
 
 def mute_all_tracks():
@@ -1328,7 +1386,7 @@ def mute_all_tracks():
 
     Audacity Documentation: Mutes all the audio tracks in the project as if you had used the mute buttons from the Track Control Panel on each track.
     """
-    return do('MuteAllTracks')
+    return do("MuteAllTracks")
 
 
 def unmute_all_tracks():
@@ -1337,7 +1395,7 @@ def unmute_all_tracks():
 
     Audacity Documentation: Unmutes all the audio tracks in the project as if you had released the mute buttons from the Track Control Panel on each track.
     """
-    return do('UnmuteAllTracks')
+    return do("UnmuteAllTracks")
 
 
 def mute_tracks():
@@ -1345,7 +1403,7 @@ def mute_tracks():
     """TODO
 
     Audacity Documentation: Mutes the selected tracks."""
-    return do('MuteTracks')
+    return do("MuteTracks")
 
 
 def unmute_tracks():
@@ -1353,7 +1411,7 @@ def unmute_tracks():
     """TODO
 
     Audacity Documentation: Unmutes the selected tracks."""
-    return do('UnmuteTracks')
+    return do("UnmuteTracks")
 
 
 def pan_left():
@@ -1361,7 +1419,7 @@ def pan_left():
     """TODO
 
     Audacity Documentation: Pan selected audio to left speaker."""
-    return do('PanLeft')
+    return do("PanLeft")
 
 
 def pan_right():
@@ -1369,7 +1427,7 @@ def pan_right():
     """TODO
 
     Audacity Documentation: Pan selected audio centrally."""
-    return do('PanRight')
+    return do("PanRight")
 
 
 def pan_center():
@@ -1377,7 +1435,7 @@ def pan_center():
     """TODO
 
     Audacity Documentation: Pan selected audio to right speaker."""
-    return do('PanCenter')
+    return do("PanCenter")
 
 
 def align__end_to_end():
@@ -1386,23 +1444,25 @@ def align__end_to_end():
 
     Audacity Documentation: Aligns the selected tracks one after the other, based on their top-to-bottom order in the project window.
     """
-    return do('Align_EndToEnd')
+    return do("Align_EndToEnd")
 
 
 def align__together():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Align the selected tracks so that they start at the same (averaged) start time."""
-    return do('Align_Together')
+    Audacity Documentation: Align the selected tracks so that they start at the same (averaged) start time.
+    """
+    return do("Align_Together")
 
 
 def align__start_to_zero():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Aligns the start of selected tracks with the start of the project."""
-    return do('Align_StartToZero')
+    Audacity Documentation: Aligns the start of selected tracks with the start of the project.
+    """
+    return do("Align_StartToZero")
 
 
 def align__start_to_sel_start():
@@ -1411,15 +1471,16 @@ def align__start_to_sel_start():
 
     Audacity Documentation: Aligns the start of selected tracks with the current cursor position or with the start of the current selection.
     """
-    return do('Align_StartToSelStart')
+    return do("Align_StartToSelStart")
 
 
 def align__start_to_sel_end():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Aligns the start of selected tracks with the end of the current selection."""
-    return do('Align_StartToSelEnd')
+    Audacity Documentation: Aligns the start of selected tracks with the end of the current selection.
+    """
+    return do("Align_StartToSelEnd")
 
 
 def align__end_to_sel_start():
@@ -1428,23 +1489,25 @@ def align__end_to_sel_start():
 
     Audacity Documentation: Aligns the end of selected tracks with the current cursor position or with the start of the current selection.
     """
-    return do('Align_EndToSelStart')
+    return do("Align_EndToSelStart")
 
 
 def align__end_to_sel_end():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Aligns the end of selected tracks with the end of the current selection."""
-    return do('Align_EndToSelEnd')
+    Audacity Documentation: Aligns the end of selected tracks with the end of the current selection.
+    """
+    return do("Align_EndToSelEnd")
 
 
 def move_selection_with_tracks():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Toggles on/off the selection moving with the realigned tracks, or staying put."""
-    return do('MoveSelectionWithTracks')
+    Audacity Documentation: Toggles on/off the selection moving with the realigned tracks, or staying put.
+    """
+    return do("MoveSelectionWithTracks")
 
 
 def sort_by_time():
@@ -1452,7 +1515,7 @@ def sort_by_time():
     """TODO
 
     Audacity Documentation: Sort tracks in order of start time."""
-    return do('SortByTime')
+    return do("SortByTime")
 
 
 def sort_by_name():
@@ -1460,7 +1523,7 @@ def sort_by_name():
     """TODO
 
     Audacity Documentation: Sort tracks in order by name."""
-    return do('SortByName')
+    return do("SortByName")
 
 
 def manage_generators():
@@ -1469,7 +1532,7 @@ def manage_generators():
 
     Audacity Documentation: Selecting this option from the Effect Menu (or the Generate Menu or Analyze Menu) takes you to a dialog where you can enable or disable particular Effects, Generators and Analyzers in Audacity. Even if you do not add any third-party plugins, you can use this to make the Effect menu shorter or longer as required. For details see Plugin Manager.
     """
-    return do('ManageGenerators')
+    return do("ManageGenerators")
 
 
 def built_in():
@@ -1478,7 +1541,7 @@ def built_in():
 
     Audacity Documentation: Shows the list of available Audacity built-in effects but only if the user has effects "Grouped by Type" in Effects Preferences.
     """
-    return do('Built-in')
+    return do("Built-in")
 
 
 def nyquist():
@@ -1487,20 +1550,20 @@ def nyquist():
 
     Audacity Documentation: Shows the list of available Nyquist effects but only if the user has effects "Grouped by Type" in Effects Preferences.
     """
-    return do('Nyquist')
+    return do("Nyquist")
 
 
 class ChirpWaveform(Enum):
-    SINE = 'Sine'
-    SQUARE = 'Square'
-    SAWTOOTH = 'Sawtooth'
-    SQUARE_NO_ALIAS = 'Square, no alias'
-    TRIANGLE = 'Triangle'  # Note: This option doesn't appear in the scripting documentation but does in the UI.
+    SINE = "Sine"
+    SQUARE = "Square"
+    SAWTOOTH = "Sawtooth"
+    SQUARE_NO_ALIAS = "Square, no alias"
+    TRIANGLE = "Triangle"  # Note: This option doesn't appear in the scripting documentation but does in the UI.
 
 
 class ChirpInterpolation(Enum):
-    LINEAR = 'Linear'
-    LOGARITHMIC = 'Logarithmic'
+    LINEAR = "Linear"
+    LOGARITHMIC = "Logarithmic"
 
 
 def chirp(
@@ -1508,8 +1571,8 @@ def chirp(
     end_frequency=1320,
     start_amplitude=0.8,
     end_amplitude=0.1,
-    waveform='Sine',
-    interpolation='Linear',
+    waveform="Sine",
+    interpolation="Linear",
 ):
     # type: (float, float, float, float, Union[ChirpWaveform, str], Union[ChirpInterpolation, str]) -> str
     """TODO
@@ -1525,30 +1588,46 @@ def chirp(
 
     # Argument type checks:
     if not isinstance(start_frequency, (float, int)):
-        raise PyAudacityException('start_frequency argument must be float or int, not ' + str(type(start_frequency)))
+        raise PyAudacityException(
+            "start_frequency argument must be float or int, not "
+            + str(type(start_frequency))
+        )
     if not isinstance(end_frequency, (float, int)):
-        raise PyAudacityException('end_frequency argument must be float or int, not ' + str(type(end_frequency)))
+        raise PyAudacityException(
+            "end_frequency argument must be float or int, not "
+            + str(type(end_frequency))
+        )
     if not isinstance(start_amplitude, (float, int)):
-        raise PyAudacityException('start_amplitude argument must be float or int, not ' + str(type(start_amplitude)))
+        raise PyAudacityException(
+            "start_amplitude argument must be float or int, not "
+            + str(type(start_amplitude))
+        )
     if not isinstance(end_amplitude, (float, int)):
-        raise PyAudacityException('end_amplitude argument must be float or int, not ' + str(type(end_amplitude)))
+        raise PyAudacityException(
+            "end_amplitude argument must be float or int, not "
+            + str(type(end_amplitude))
+        )
 
     # Argument value checks:
-    if waveform.lower() not in ('sine', 'square', 'sawtooth', 'square, no alias'):
+    if waveform.lower() not in ("sine", "square", "sawtooth", "square, no alias"):
         raise PyAudacityException(
             'waveform argument must be one of "Sine", "Square", "Sawtooth", or "Square, no alias"'
         )
-    if interpolation.lower() not in ('linear', 'logarithmic'):
-        raise PyAudacityException('interpolation argument must be one of "Linear" or "Logarithmic"')
+    if interpolation.lower() not in ("linear", "logarithmic"):
+        raise PyAudacityException(
+            'interpolation argument must be one of "Linear" or "Logarithmic"'
+        )
 
     if not (0.0 <= start_amplitude <= 1.0):
-        raise PyAudacityException('start_amplitude argument must be between 0.0 and 1.0')
+        raise PyAudacityException(
+            "start_amplitude argument must be between 0.0 and 1.0"
+        )
     if not (0.0 <= end_amplitude <= 1.0):
-        raise PyAudacityException('end_amplitude argument must be between 0.0 and 1.0')
+        raise PyAudacityException("end_amplitude argument must be between 0.0 and 1.0")
     if start_frequency < 0:
-        raise PyAudacityException('start_frequency must be positive')
+        raise PyAudacityException("start_frequency must be positive")
     if end_frequency < 0:
-        raise PyAudacityException('end_frequency must be positive')
+        raise PyAudacityException("end_frequency must be positive")
 
     # Convert str args to their expected case:
     waveform = waveform[0].upper() + waveform[1:].lower()
@@ -1557,12 +1636,17 @@ def chirp(
     # Run macro:
     return do(
         'Chirp: StartFreq="{}" EndFreq="{}" StartAmp="{}" EndAmp="{}" Waveform="{}" Interpolation="{}"'.format(
-            start_frequency, end_frequency, start_amplitude, end_amplitude, waveform, interpolation
+            start_frequency,
+            end_frequency,
+            start_amplitude,
+            end_amplitude,
+            waveform,
+            interpolation,
         )
     )
 
 
-def dtmf_tones(DTMF_sequence='audacity', duty_cycle=55, amplitude=0.8):
+def dtmf_tones(DTMF_sequence="audacity", duty_cycle=55, amplitude=0.8):
     # type: (str, float, float) -> str
     """This macro is broken. The UI specifies Tone/Silence Ratio instead of Duty Cycle,
     but the macro can't seem to set this. Passing any value for Duty Cycle doesn't have
@@ -1578,22 +1662,32 @@ def dtmf_tones(DTMF_sequence='audacity', duty_cycle=55, amplitude=0.8):
     """
 
     if not isinstance(DTMF_sequence, str):
-        raise PyAudacityException('DTMF_sequence argument must be a str, not ' + str(type(DTMF_sequence)))
+        raise PyAudacityException(
+            "DTMF_sequence argument must be a str, not " + str(type(DTMF_sequence))
+        )
     if not isinstance(duty_cycle, (float, int)):
-        raise PyAudacityException('duty_cycle argument must be float or int, not ' + str(type(duty_cycle)))
+        raise PyAudacityException(
+            "duty_cycle argument must be float or int, not " + str(type(duty_cycle))
+        )
     if not isinstance(amplitude, (float, int)):
-        raise PyAudacityException('amplitude argument must be float or int, not ' + str(type(amplitude)))
+        raise PyAudacityException(
+            "amplitude argument must be float or int, not " + str(type(amplitude))
+        )
 
-    return do('DtmfTones: Sequence="{}" DutyCycle="{}" Amplitude="{}"'.format(DTMF_sequence, duty_cycle, amplitude))
+    return do(
+        'DtmfTones: Sequence="{}" DutyCycle="{}" Amplitude="{}"'.format(
+            DTMF_sequence, duty_cycle, amplitude
+        )
+    )
 
 
 class NoiseType(Enum):
-    WHITE = 'White'
-    PINK = 'Pink'
-    BROWNIAN = 'Brownian'
+    WHITE = "White"
+    PINK = "Pink"
+    BROWNIAN = "Brownian"
 
 
-def noise(noise_type='White', amplitude=0.8):
+def noise(noise_type="White", amplitude=0.8):
     # type: (Union[NoiseType, str], float) -> str
     """Fills the selected area with noise.
 
@@ -1604,27 +1698,31 @@ def noise(noise_type='White', amplitude=0.8):
         noise_type = noise_type.value
     noise_type = noise_type.title()
 
-    if noise_type not in ('White', 'Pink', 'Brownian'):
-        raise PyAudacityException('type argument must be one of "White", "Pink" or "Brownian"')
+    if noise_type not in ("White", "Pink", "Brownian"):
+        raise PyAudacityException(
+            'type argument must be one of "White", "Pink" or "Brownian"'
+        )
     if not isinstance(amplitude, (float, int)):
-        raise PyAudacityException('amplitude argument must be float or int, not ' + str(type(amplitude)))
+        raise PyAudacityException(
+            "amplitude argument must be float or int, not " + str(type(amplitude))
+        )
 
     # Argument value checks:
     if not (0.0 <= amplitude <= 1.0):
-        raise PyAudacityException('amplitude argument must be between 0.0 and 1.0')
+        raise PyAudacityException("amplitude argument must be between 0.0 and 1.0")
 
     return do('Noise: Type="{}" Amplitude="{}"'.format(noise_type, amplitude))
 
 
 class ToneWaveform(Enum):
-    SINE = 'Sine'
-    SQUARE = 'Square'
-    SAWTOOTH = 'Sawtooth'
-    SQUARE_NO_ALIAS = 'Square, no alias'
-    TRIANGLE = 'Triangle'  # Note: This option doesn't appear in the scripting documentation but does in the UI.
+    SINE = "Sine"
+    SQUARE = "Square"
+    SAWTOOTH = "Sawtooth"
+    SQUARE_NO_ALIAS = "Square, no alias"
+    TRIANGLE = "Triangle"  # Note: This option doesn't appear in the scripting documentation but does in the UI.
 
 
-def tone(frequency=440, amplitude=0.8, waveform='Sine'):
+def tone(frequency=440, amplitude=0.8, waveform="Sine"):
     # type: (float, float, Union[ToneWaveform, str]) -> str
     """TODO
 
@@ -1638,25 +1736,33 @@ def tone(frequency=440, amplitude=0.8, waveform='Sine'):
         waveform = waveform.value
 
     if not isinstance(frequency, (float, int)):
-        raise PyAudacityException('frequency argument must be float or int, not ' + str(type(frequency)))
+        raise PyAudacityException(
+            "frequency argument must be float or int, not " + str(type(frequency))
+        )
     if not isinstance(amplitude, (float, int)):
-        raise PyAudacityException('amplitude argument must be float or int, not ' + str(type(amplitude)))
-    if waveform.lower() not in ('sine', 'square', 'sawtooth', 'square, no alias'):
+        raise PyAudacityException(
+            "amplitude argument must be float or int, not " + str(type(amplitude))
+        )
+    if waveform.lower() not in ("sine", "square", "sawtooth", "square, no alias"):
         raise PyAudacityException(
             'waveform argument must be one of "Sine", "Square", "Sawtooth", or "Square, no alias"'
         )
 
     waveform = waveform[0].upper() + waveform[1:].lower()
 
-    return do('Tone: Frequency="{}" Amplitude="{}" Waveform="{}"'.format(frequency, amplitude, waveform))
+    return do(
+        'Tone: Frequency="{}" Amplitude="{}" Waveform="{}"'.format(
+            frequency, amplitude, waveform
+        )
+    )
 
 
 class PluckFade(Enum):
-    ABRUPT = 'Abrupt'
-    GRADUAL = 'Gradual'
+    ABRUPT = "Abrupt"
+    GRADUAL = "Gradual"
 
 
-def pluck(pitch=60, fade='Abrupt', duration=1.0):
+def pluck(pitch=60, fade="Abrupt", duration=1.0):
     # type: (int, Union[PluckFade, str], float) -> str
     """TODO
 
@@ -1671,15 +1777,19 @@ def pluck(pitch=60, fade='Abrupt', duration=1.0):
     fade = fade.title()
 
     if not isinstance(pitch, int):
-        raise PyAudacityException('pitch argument must be int, not ' + str(type(pitch)))
+        raise PyAudacityException("pitch argument must be int, not " + str(type(pitch)))
     if not isinstance(duration, (float, int)):
-        raise PyAudacityException('duration argument must be float or int, not ' + str(type(duration)))
-    if fade not in ('Abrupt', 'Gradual'):
+        raise PyAudacityException(
+            "duration argument must be float or int, not " + str(type(duration))
+        )
+    if fade not in ("Abrupt", "Gradual"):
         raise PyAudacityException('fade argument must be one of "Abrupt" or "Gradual"')
 
     # The user interface says 60 seconds is the max duration.
     if duration > 60:
-        raise PyAudacityException('duration is larger than the 60 seconds maximum allowed limit')
+        raise PyAudacityException(
+            "duration is larger than the 60 seconds maximum allowed limit"
+        )
 
     # Note: The parameter names are lowercase in the documentation so I'm making them lowercase here.
     # https://manual.audacityteam.org/man/scripting_reference.html
@@ -1687,14 +1797,14 @@ def pluck(pitch=60, fade='Abrupt', duration=1.0):
 
 
 class RhythmTrackBeatSound(Enum):
-    METRONOME_TICK = 'Metronome Tick'
-    PING_SHORT = 'Ping (short)'
-    PING_LONG = 'Ping (long)'
-    COWBELL = 'Cowbell'
-    RESONANT_NOISE = 'Resonant Noise'
-    NOISE_CLICK = 'Noise Click'
-    DRIP_SHORT = 'Drip (short)'
-    DRIP_LONG = 'Drip (long)'
+    METRONOME_TICK = "Metronome Tick"
+    PING_SHORT = "Ping (short)"
+    PING_LONG = "Ping (long)"
+    COWBELL = "Cowbell"
+    RESONANT_NOISE = "Resonant Noise"
+    NOISE_CLICK = "Noise Click"
+    DRIP_SHORT = "Drip (short)"
+    DRIP_LONG = "Drip (long)"
 
 
 def rhythm_track(
@@ -1704,7 +1814,7 @@ def rhythm_track(
     number_of_bars=16,
     rhythm_track_duration=0,
     start_time_offset=0,
-    beat_sound='Metronome',
+    beat_sound="Metronome",
     pitch_of_strong_beat=84,
     pitch_of_weak_beat=0,
 ):
@@ -1719,46 +1829,64 @@ def rhythm_track(
         beat_sound = beat_sound.value
 
     if not isinstance(tempo, (float, int)):
-        raise PyAudacityException('tempo argument must be float or int, not ' + str(type(tempo)))
+        raise PyAudacityException(
+            "tempo argument must be float or int, not " + str(type(tempo))
+        )
     if not isinstance(beats_per_bar, int):
-        raise PyAudacityException('beats_per_bar argument must be int, not ' + str(type(beats_per_bar)))
+        raise PyAudacityException(
+            "beats_per_bar argument must be int, not " + str(type(beats_per_bar))
+        )
     if not isinstance(swing, (float, int)):
-        raise PyAudacityException('swing argument must be float or int, not ' + str(type(swing)))
+        raise PyAudacityException(
+            "swing argument must be float or int, not " + str(type(swing))
+        )
     if not isinstance(number_of_bars, int):
-        raise PyAudacityException('number_of_bars argument must be int, not ' + str(type(number_of_bars)))
+        raise PyAudacityException(
+            "number_of_bars argument must be int, not " + str(type(number_of_bars))
+        )
     if not isinstance(rhythm_track_duration, (float, int)):
         raise PyAudacityException(
-            'rhythm_track_duration argument must be float or int, not ' + str(type(rhythm_track_duration))
+            "rhythm_track_duration argument must be float or int, not "
+            + str(type(rhythm_track_duration))
         )
     if not isinstance(start_time_offset, (float, int)):
         raise PyAudacityException(
-            'start_time_offset argument must be float or int, not ' + str(type(start_time_offset))
+            "start_time_offset argument must be float or int, not "
+            + str(type(start_time_offset))
         )
     if beat_sound.lower() not in (
-        'metronome tick',
-        'ping (short)',
-        'ping (long)',
-        'cowbell',
-        'resonant noise',
-        'noise click',
-        'drip (short)',
-        'drip (long)',
+        "metronome tick",
+        "ping (short)",
+        "ping (long)",
+        "cowbell",
+        "resonant noise",
+        "noise click",
+        "drip (short)",
+        "drip (long)",
     ):
-        raise PyAudacityException('beat_sound argument must be one of "Abrupt" or "Gradual"')
+        raise PyAudacityException(
+            'beat_sound argument must be one of "Abrupt" or "Gradual"'
+        )
     if not isinstance(pitch_of_strong_beat, int):
-        raise PyAudacityException('pitch_of_strong_beat argument must be int, not ' + str(type(pitch_of_strong_beat)))
+        raise PyAudacityException(
+            "pitch_of_strong_beat argument must be int, not "
+            + str(type(pitch_of_strong_beat))
+        )
     if not isinstance(pitch_of_weak_beat, int):
-        raise PyAudacityException('pitch_of_weak_beat argument must be int, not ' + str(type(pitch_of_weak_beat)))
+        raise PyAudacityException(
+            "pitch_of_weak_beat argument must be int, not "
+            + str(type(pitch_of_weak_beat))
+        )
 
     beat_sound = {
-        'metronome tick': 'Metronome',
-        'ping (short)': 'Ping (short)',
-        'ping (long)': 'Ping (long)',
-        'cowbell': 'Cowbell',
-        'resonant noise': 'ResonantNoise',
-        'noise click': 'NoiseClick',
-        'drip (short)': 'Drip (short)',
-        'drip (long)': 'Drip (long)',
+        "metronome tick": "Metronome",
+        "ping (short)": "Ping (short)",
+        "ping (long)": "Ping (long)",
+        "cowbell": "Cowbell",
+        "resonant noise": "ResonantNoise",
+        "noise click": "NoiseClick",
+        "drip (short)": "Drip (short)",
+        "drip (long)": "Drip (long)",
     }[beat_sound.lower()]
 
     # The documentation has the parameters as lowercase, so I do too:
@@ -1777,33 +1905,55 @@ def rhythm_track(
     )
 
 
-def risset_drum(frequency=0, decay=0, center_frequency_of_noise=0, width_of_noise_band=0, noise=0, gain=0):
+def risset_drum(
+    frequency=0,
+    decay=0,
+    center_frequency_of_noise=0,
+    width_of_noise_band=0,
+    noise=0,
+    gain=0,
+):
     # type: (float, float, float, float, float, float) -> str
     """TODO
 
     Audacity Documentation: Produces a realistic drum sound."""
 
     if not isinstance(frequency, (float, int)):
-        raise PyAudacityException('frequency argument must be float or int, not ' + str(type(frequency)))
+        raise PyAudacityException(
+            "frequency argument must be float or int, not " + str(type(frequency))
+        )
     if not isinstance(decay, (float, int)):
-        raise PyAudacityException('decay argument must be float or int, not ' + str(type(decay)))
+        raise PyAudacityException(
+            "decay argument must be float or int, not " + str(type(decay))
+        )
     if not isinstance(center_frequency_of_noise, (float, int)):
         raise PyAudacityException(
-            'center_frequency_of_noise argument must be float or int, not ' + str(type(center_frequency_of_noise))
+            "center_frequency_of_noise argument must be float or int, not "
+            + str(type(center_frequency_of_noise))
         )
     if not isinstance(width_of_noise_band, (float, int)):
         raise PyAudacityException(
-            'width_of_noise_band argument must be float or int, not ' + str(type(width_of_noise_band))
+            "width_of_noise_band argument must be float or int, not "
+            + str(type(width_of_noise_band))
         )
     if not isinstance(noise, (float, int)):
-        raise PyAudacityException('noise argument must be float or int, not ' + str(type(noise)))
+        raise PyAudacityException(
+            "noise argument must be float or int, not " + str(type(noise))
+        )
     if not isinstance(gain, (float, int)):
-        raise PyAudacityException('gain argument must be float or int, not ' + str(type(gain)))
+        raise PyAudacityException(
+            "gain argument must be float or int, not " + str(type(gain))
+        )
 
     # The documentation has lowercase parameters, so I do too:
     return do(
         'RissetDrum: freq="{}" decay="{}" cf="{}" bw="{}" noise="{}" gain="{}"'.format(
-            frequency, decay, center_frequency_of_noise, width_of_noise_band, noise, gain
+            frequency,
+            decay,
+            center_frequency_of_noise,
+            width_of_noise_band,
+            noise,
+            gain,
         )
     )
 
@@ -1814,15 +1964,16 @@ def manage_effects():
 
     Audacity Documentation: Selecting this option from the Effect Menu (or the Generate Menu or Analyze Menu) takes you to a dialog where you can enable or disable particular Effects, Generators and Analyzers in Audacity. Even if you do not add any third-party plugins, you can use this to make the Effect menu shorter or longer as required. For details see Plugin Manager.
     """
-    return do('ManageEffects')
+    return do("ManageEffects")
 
 
 def repeat_last_effect():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Repeats the last used effect at its last used settings and without displaying any dialog."""
-    return do('RepeatLastEffect')
+    Audacity Documentation: Repeats the last used effect at its last used settings and without displaying any dialog.
+    """
+    return do("RepeatLastEffect")
 
 
 def ladspa():
@@ -1831,19 +1982,24 @@ def ladspa():
 
     Audacity Documentation: Shows the list of available LADSPA effects but only if the user has effects "Grouped by Type" in Effects Preferences.
     """
-    return do('LADSPA')
+    return do("LADSPA")
 
 
 def amplify(ratio=0.9, allow_clipping=False):
     # type: (float, bool) -> str
     """TODO
 
-    Audacity Documentation: Increases or decreases the volume of the audio you have selected."""
+    Audacity Documentation: Increases or decreases the volume of the audio you have selected.
+    """
 
     if not isinstance(ratio, (float, int)):
-        raise PyAudacityException('ratio argument must be float or int, not ' + str(type(ratio)))
+        raise PyAudacityException(
+            "ratio argument must be float or int, not " + str(type(ratio))
+        )
     if not isinstance(allow_clipping, bool):
-        raise PyAudacityException('allow_clipping argument must be a bool, not' + str(type(allow_clipping)))
+        raise PyAudacityException(
+            "allow_clipping argument must be a bool, not" + str(type(allow_clipping))
+        )
 
     return do('Amplify: Ratio="{}" AllowClipping="{}"'.format(ratio, allow_clipping))
 
@@ -1864,27 +2020,39 @@ def auto_duck(
     """
 
     if not isinstance(duck_amount_db, (float, int)):
-        raise PyAudacityException('duck_amount_db argument must be float or int, not ' + str(type(duck_amount_db)))
+        raise PyAudacityException(
+            "duck_amount_db argument must be float or int, not "
+            + str(type(duck_amount_db))
+        )
     if not isinstance(inner_fade_down_len, (float, int)):
         raise PyAudacityException(
-            'inner_fade_down_len argument must be float or int, not ' + str(type(inner_fade_down_len))
+            "inner_fade_down_len argument must be float or int, not "
+            + str(type(inner_fade_down_len))
         )
     if not isinstance(inner_fade_up_len, (float, int)):
         raise PyAudacityException(
-            'inner_fade_up_len argument must be float or int, not ' + str(type(inner_fade_up_len))
+            "inner_fade_up_len argument must be float or int, not "
+            + str(type(inner_fade_up_len))
         )
     if not isinstance(outer_fade_down_len, (float, int)):
         raise PyAudacityException(
-            'outer_fade_down_len argument must be float or int, not ' + str(type(outer_fade_down_len))
+            "outer_fade_down_len argument must be float or int, not "
+            + str(type(outer_fade_down_len))
         )
     if not isinstance(outer_fade_up_len, (float, int)):
         raise PyAudacityException(
-            'outer_fade_up_len argument must be float or int, not ' + str(type(outer_fade_up_len))
+            "outer_fade_up_len argument must be float or int, not "
+            + str(type(outer_fade_up_len))
         )
     if not isinstance(threshold_db, (float, int)):
-        raise PyAudacityException('threshold_db argument must be float or int, not ' + str(type(threshold_db)))
+        raise PyAudacityException(
+            "threshold_db argument must be float or int, not " + str(type(threshold_db))
+        )
     if not isinstance(maximum_pause, (float, int)):
-        raise PyAudacityException('maximum_pause argument must be float or int, not ' + str(type(maximum_pause)))
+        raise PyAudacityException(
+            "maximum_pause argument must be float or int, not "
+            + str(type(maximum_pause))
+        )
 
     return do(
         'AutoDuck: DuckAmountDb="{}" InnerFadeDownLen="{}" InnerFadeUpLen="{}" OuterFadeDownLen="{}" OuterFadeUpLen="{}" ThresholdDb="{}" MaximumPause="{}"'.format(
@@ -1907,13 +2075,21 @@ def bass_and_treble(bass=0, treble=0, gain=0, link_sliders=False):
     """
 
     if not isinstance(bass, (float, int)):
-        raise PyAudacityException('bass argument must be float or int, not ' + str(type(bass)))
+        raise PyAudacityException(
+            "bass argument must be float or int, not " + str(type(bass))
+        )
     if not isinstance(treble, (float, int)):
-        raise PyAudacityException('treble argument must be float or int, not ' + str(type(treble)))
+        raise PyAudacityException(
+            "treble argument must be float or int, not " + str(type(treble))
+        )
     if not isinstance(gain, (float, int)):
-        raise PyAudacityException('gain argument must be float or int, not ' + str(type(gain)))
+        raise PyAudacityException(
+            "gain argument must be float or int, not " + str(type(gain))
+        )
     if not isinstance(link_sliders, bool):
-        raise PyAudacityException('link_sliders argument must be a bool, not' + str(type(link_sliders)))
+        raise PyAudacityException(
+            "link_sliders argument must be a bool, not" + str(type(link_sliders))
+        )
 
     # TODO - The documentation shows it as "Link Sliders" but I don't know if the space is intentional or not.
     # There's no way to tell since Audacity's macro system doesn't give errors for bad parameter names.
@@ -1924,7 +2100,8 @@ def change_pitch(percentage=0.0, use_high_quality_stretching=False):
     # type: (float, bool) -> str
     """TODO
 
-    Audacity Documentation: Change the pitch of a selection without changing its tempo."""
+    Audacity Documentation: Change the pitch of a selection without changing its tempo.
+    """
 
     # TODO - the documentation is unclear as to what SBSMS stands for, but it's
     # a bool and the only checkbox in the Change Pitch dialog is the one marked
@@ -1936,13 +2113,20 @@ def change_pitch(percentage=0.0, use_high_quality_stretching=False):
     # aren't captured by the parameters for this macro. What's up with that?
 
     if not isinstance(percentage, (float, int)):
-        raise PyAudacityException('percentage argument must be float or int, not ' + str(type(percentage)))
+        raise PyAudacityException(
+            "percentage argument must be float or int, not " + str(type(percentage))
+        )
     if not isinstance(use_high_quality_stretching, bool):
         raise PyAudacityException(
-            'use_high_quality_stretching argument must be a bool, not' + str(type(use_high_quality_stretching))
+            "use_high_quality_stretching argument must be a bool, not"
+            + str(type(use_high_quality_stretching))
         )
 
-    return do('ChangePitch: Percentage="{}" SBSMS="{}"'.format(percentage, use_high_quality_stretching))
+    return do(
+        'ChangePitch: Percentage="{}" SBSMS="{}"'.format(
+            percentage, use_high_quality_stretching
+        )
+    )
 
 
 def change_speed(percentage=0.0):
@@ -1952,7 +2136,9 @@ def change_speed(percentage=0.0):
     Audacity Documentation: Change the speed of a selection, also changing its pitch."""
 
     if not isinstance(percentage, (float, int)):
-        raise PyAudacityException('percentage argument must be float or int, not ' + str(type(percentage)))
+        raise PyAudacityException(
+            "percentage argument must be float or int, not " + str(type(percentage))
+        )
 
     return do('ChangeSpeed: Percentage="{}"'.format(percentage))
 
@@ -1961,16 +2147,24 @@ def change_tempo(percentage=0.0, use_high_quality_stretching=False):
     # type: (float, bool) -> str
     """TODO
 
-    Audacity Documentation: Change the tempo and length (duration) of a selection without changing its pitch."""
+    Audacity Documentation: Change the tempo and length (duration) of a selection without changing its pitch.
+    """
 
     if not isinstance(percentage, (float, int)):
-        raise PyAudacityException('percentage argument must be float or int, not ' + str(type(percentage)))
+        raise PyAudacityException(
+            "percentage argument must be float or int, not " + str(type(percentage))
+        )
     if not isinstance(use_high_quality_stretching, bool):
         raise PyAudacityException(
-            'use_high_quality_stretching argument must be a bool, not' + str(type(use_high_quality_stretching))
+            "use_high_quality_stretching argument must be a bool, not"
+            + str(type(use_high_quality_stretching))
         )
 
-    return do('ChangeTempo: Percentage="{}" SBSMS="{}"'.format(percentage, use_high_quality_stretching))
+    return do(
+        'ChangeTempo: Percentage="{}" SBSMS="{}"'.format(
+            percentage, use_high_quality_stretching
+        )
+    )
 
 
 def click_removal(threshold=200, width=20):
@@ -1981,15 +2175,23 @@ def click_removal(threshold=200, width=20):
     """
 
     if not isinstance(threshold, int):
-        raise PyAudacityException('threshold argument must be int, not ' + str(type(threshold)))
+        raise PyAudacityException(
+            "threshold argument must be int, not " + str(type(threshold))
+        )
     if not isinstance(width, int):
-        raise PyAudacityException('width argument must be int, not ' + str(type(width)))
+        raise PyAudacityException("width argument must be int, not " + str(type(width)))
 
     return do('ClickRemoval: Threshold="{}" Width="{}"'.format(threshold, width))
 
 
 def compressor(
-    threshold=-12.0, noise_floor=-40.0, ratio=2.0, attack_time=0.2, release_time=1.0, normalize=True, use_peak=False
+    threshold=-12.0,
+    noise_floor=-40.0,
+    ratio=2.0,
+    attack_time=0.2,
+    release_time=1.0,
+    normalize=True,
+    use_peak=False,
 ):
     # type: (float, float, float, float, float, bool, bool) -> str
     """TODO
@@ -1998,23 +2200,43 @@ def compressor(
     """
 
     if not isinstance(threshold, (float, int)):
-        raise PyAudacityException('threshold argument must be float or int, not ' + str(type(threshold)))
+        raise PyAudacityException(
+            "threshold argument must be float or int, not " + str(type(threshold))
+        )
     if not isinstance(noise_floor, (float, int)):
-        raise PyAudacityException('noise_floor argument must be float or int, not ' + str(type(noise_floor)))
+        raise PyAudacityException(
+            "noise_floor argument must be float or int, not " + str(type(noise_floor))
+        )
     if not isinstance(ratio, (float, int)):
-        raise PyAudacityException('ratio argument must be float or int, not ' + str(type(ratio)))
+        raise PyAudacityException(
+            "ratio argument must be float or int, not " + str(type(ratio))
+        )
     if not isinstance(attack_time, (float, int)):
-        raise PyAudacityException('attack_time argument must be float or int, not ' + str(type(attack_time)))
+        raise PyAudacityException(
+            "attack_time argument must be float or int, not " + str(type(attack_time))
+        )
     if not isinstance(release_time, (float, int)):
-        raise PyAudacityException('release_time argument must be float or int, not ' + str(type(release_time)))
+        raise PyAudacityException(
+            "release_time argument must be float or int, not " + str(type(release_time))
+        )
     if not isinstance(normalize, bool):
-        raise PyAudacityException('normalize argument must be a bool, not' + str(type(normalize)))
+        raise PyAudacityException(
+            "normalize argument must be a bool, not" + str(type(normalize))
+        )
     if not isinstance(use_peak, bool):
-        raise PyAudacityException('use_peak argument must be a bool, not' + str(type(use_peak)))
+        raise PyAudacityException(
+            "use_peak argument must be a bool, not" + str(type(use_peak))
+        )
 
     return do(
         'Compressor: Threshold="{}" NoiseFloor="{}" Ratio="{}" AttackTime="{}" ReleaseTime="{}" Normalize="{}" UsePeak="{}"'.format(
-            threshold, noise_floor, ratio, attack_time, release_time, normalize, use_peak
+            threshold,
+            noise_floor,
+            ratio,
+            attack_time,
+            release_time,
+            normalize,
+            use_peak,
         )
     )
 
@@ -2035,9 +2257,13 @@ def echo(delay=1.0, decay=0.5):
     """
 
     if not isinstance(delay, (float, int)):
-        raise PyAudacityException('delay argument must be float or int, not ' + str(type(delay)))
+        raise PyAudacityException(
+            "delay argument must be float or int, not " + str(type(delay))
+        )
     if not isinstance(decay, (float, int)):
-        raise PyAudacityException('decay argument must be float or int, not ' + str(type(decay)))
+        raise PyAudacityException(
+            "decay argument must be float or int, not " + str(type(decay))
+        )
 
     return do('Echo: Delay="{}" Decay="{}"'.format(delay, decay))
 
@@ -2049,7 +2275,7 @@ def fade_in():
     Audacity Documentation: Applies a linear fade-in to the selected audio - the rapidity of the fade-in depends entirely on the length of the selection it is applied to. For a more customizable logarithmic fade, use the Envelope Tool on the Tools Toolbar.
     """
 
-    return do('FadeIn')
+    return do("FadeIn")
 
 
 def fade_out():
@@ -2059,7 +2285,7 @@ def fade_out():
     Audacity Documentation: Applies a linear fade-out to the selected audio - the rapidity of the fade-out depends entirely on the length of the selection it is applied to. For a more customizable logarithmic fade, use the Envelope Tool on the Tools Toolbar.
     """
 
-    return do('FadeOut')
+    return do("FadeOut")
 
 
 def filter_curve():
@@ -2083,25 +2309,42 @@ def invert():
     Audacity Documentation: This effect flips the audio samples upside-down. This normally does not affect the sound of the audio at all. It is occasionally useful for vocal removal.
     """
 
-    return do('Invert')
+    return do("Invert")
 
 
-def loudness_normalization(stereo_independent=False, LUFS_level=-23.0, RMS_level=-20.0, dual_mono=True, normalize_to=0):
+def loudness_normalization(
+    stereo_independent=False,
+    LUFS_level=-23.0,
+    RMS_level=-20.0,
+    dual_mono=True,
+    normalize_to=0,
+):
     # type: (bool, float, float, bool, int) -> str
     """TODO
 
     Audacity Documentation: Changes the perceived loudness of the audio."""
 
     if not isinstance(stereo_independent, bool):
-        raise PyAudacityException('stereo_independent argument must be a bool, not' + str(type(stereo_independent)))
+        raise PyAudacityException(
+            "stereo_independent argument must be a bool, not"
+            + str(type(stereo_independent))
+        )
     if not isinstance(LUFS_level, (float, int)):
-        raise PyAudacityException('LUFS_level argument must be float or int, not ' + str(type(LUFS_level)))
+        raise PyAudacityException(
+            "LUFS_level argument must be float or int, not " + str(type(LUFS_level))
+        )
     if not isinstance(RMS_level, (float, int)):
-        raise PyAudacityException('RMS_level argument must be float or int, not ' + str(type(RMS_level)))
+        raise PyAudacityException(
+            "RMS_level argument must be float or int, not " + str(type(RMS_level))
+        )
     if not isinstance(dual_mono, bool):
-        raise PyAudacityException('dual_mono argument must be a bool, not' + str(type(dual_mono)))
+        raise PyAudacityException(
+            "dual_mono argument must be a bool, not" + str(type(dual_mono))
+        )
     if not isinstance(normalize_to, int):
-        raise PyAudacityException('normalize_to argument must be int, not ' + str(type(normalize_to)))
+        raise PyAudacityException(
+            "normalize_to argument must be int, not " + str(type(normalize_to))
+        )
 
     return do(
         'LoudnessNormalization: StereoIndependent="{}" LUFSLevel="{}" RMFSLevel="{}" DualMono="{}" NormalizeTo="{}"'.format(
@@ -2120,7 +2363,9 @@ def loudness_normalization(stereo_independent=False, LUFS_level=-23.0, RMS_level
 #    return do('NoiseReduction')
 
 
-def normalize(peak_level=-1.0, apply_gain=True, remove_dc_offset=True, stereo_independent=False):
+def normalize(
+    peak_level=-1.0, apply_gain=True, remove_dc_offset=True, stereo_independent=False
+):
     # type: (float, bool, bool, bool) -> str
     """TODO
 
@@ -2128,13 +2373,23 @@ def normalize(peak_level=-1.0, apply_gain=True, remove_dc_offset=True, stereo_in
     """
 
     if not isinstance(peak_level, (float, int)):
-        raise PyAudacityException('peak_level argument must be float or int, not ' + str(type(peak_level)))
+        raise PyAudacityException(
+            "peak_level argument must be float or int, not " + str(type(peak_level))
+        )
     if not isinstance(apply_gain, bool):
-        raise PyAudacityException('apply_gain argument must be a bool, not' + str(type(apply_gain)))
+        raise PyAudacityException(
+            "apply_gain argument must be a bool, not" + str(type(apply_gain))
+        )
     if not isinstance(remove_dc_offset, bool):
-        raise PyAudacityException('remove_dc_offset argument must be a bool, not' + str(type(remove_dc_offset)))
+        raise PyAudacityException(
+            "remove_dc_offset argument must be a bool, not"
+            + str(type(remove_dc_offset))
+        )
     if not isinstance(stereo_independent, bool):
-        raise PyAudacityException('stereo_independent argument must be a bool, not' + str(type(stereo_independent)))
+        raise PyAudacityException(
+            "stereo_independent argument must be a bool, not"
+            + str(type(stereo_independent))
+        )
 
     return do(
         'Normalize: PeakLevel="{}" ApplyGain="{}" RemoveDcOffset="{}" StereoIndependent="{}"'.format(
@@ -2151,15 +2406,27 @@ def paulstretch(stretch_factor=10.0, time_resolution=0.25):
     """
 
     if not isinstance(stretch_factor, (float, int)):
-        raise PyAudacityException('stretch_factor argument must be float or int, not ' + str(type(stretch_factor)))
+        raise PyAudacityException(
+            "stretch_factor argument must be float or int, not "
+            + str(type(stretch_factor))
+        )
     if not isinstance(time_resolution, (float, int)):
-        raise PyAudacityException('time_resolution argument must be float or int, not ' + str(type(time_resolution)))
+        raise PyAudacityException(
+            "time_resolution argument must be float or int, not "
+            + str(type(time_resolution))
+        )
 
     # TODO - documentation uses "Time Resolution" with a space. Check this out. I assume that there is no space for now.
-    return do('Paulstretch: StretchFactor="{}" TimeResolution="{}"'.format(stretch_factor, time_resolution))
+    return do(
+        'Paulstretch: StretchFactor="{}" TimeResolution="{}"'.format(
+            stretch_factor, time_resolution
+        )
+    )
 
 
-def phaser(stages=2, dry_wet=128, frequency=0.4, phase=0.0, depth=100, feedback=0, gain=-6.0):
+def phaser(
+    stages=2, dry_wet=128, frequency=0.4, phase=0.0, depth=100, feedback=0, gain=-6.0
+):
     # type: (int, int, float, float, int, int, float) -> str
     """TODO
 
@@ -2167,19 +2434,31 @@ def phaser(stages=2, dry_wet=128, frequency=0.4, phase=0.0, depth=100, feedback=
     """
 
     if not isinstance(stages, int):
-        raise PyAudacityException('stages argument must be int, not ' + str(type(stages)))
+        raise PyAudacityException(
+            "stages argument must be int, not " + str(type(stages))
+        )
     if not isinstance(dry_wet, int):
-        raise PyAudacityException('dry_wet argument must be int, not ' + str(type(dry_wet)))
+        raise PyAudacityException(
+            "dry_wet argument must be int, not " + str(type(dry_wet))
+        )
     if not isinstance(frequency, (float, int)):
-        raise PyAudacityException('frequency argument must be float or int, not ' + str(type(frequency)))
+        raise PyAudacityException(
+            "frequency argument must be float or int, not " + str(type(frequency))
+        )
     if not isinstance(phase, (float, int)):
-        raise PyAudacityException('phase argument must be float or int, not ' + str(type(phase)))
+        raise PyAudacityException(
+            "phase argument must be float or int, not " + str(type(phase))
+        )
     if not isinstance(depth, int):
-        raise PyAudacityException('depth argument must be int, not ' + str(type(depth)))
+        raise PyAudacityException("depth argument must be int, not " + str(type(depth)))
     if not isinstance(feedback, int):
-        raise PyAudacityException('feedback argument must be int, not ' + str(type(feedback)))
+        raise PyAudacityException(
+            "feedback argument must be int, not " + str(type(feedback))
+        )
     if not isinstance(gain, (float, int)):
-        raise PyAudacityException('gain argument must be float or int, not ' + str(type(gain)))
+        raise PyAudacityException(
+            "gain argument must be float or int, not " + str(type(gain))
+        )
 
     return do(
         'Phaser: Stages="{}" DryWet="{}" Freq="{}" Phase="{}" Depth="{}" Feedback="{}" Gain="{}"'.format(
@@ -2192,9 +2471,10 @@ def repair():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Fix one particular short click, pop or other glitch no more than 128 samples long."""
+    Audacity Documentation: Fix one particular short click, pop or other glitch no more than 128 samples long.
+    """
 
-    return do('Repair')
+    return do("Repair")
 
 
 def repeat(count=1):
@@ -2204,7 +2484,7 @@ def repeat(count=1):
     Audacity Documentation: Repeats the selection the specified number of times."""
 
     if not isinstance(count, int):
-        raise PyAudacityException('count argument must be int, not ' + str(type(count)))
+        raise PyAudacityException("count argument must be int, not " + str(type(count)))
 
     return do('Repeat: Count="{}"'.format(count))
 
@@ -2228,29 +2508,58 @@ def reverb(
     """
 
     if not isinstance(room_size, (float, int)):
-        raise PyAudacityException('room_size argument must be float or int, not ' + str(type(room_size)))
+        raise PyAudacityException(
+            "room_size argument must be float or int, not " + str(type(room_size))
+        )
     if not isinstance(delay, (float, int)):
-        raise PyAudacityException('delay argument must be float or int, not ' + str(type(delay)))
+        raise PyAudacityException(
+            "delay argument must be float or int, not " + str(type(delay))
+        )
     if not isinstance(reverberance, (float, int)):
-        raise PyAudacityException('reverberance argument must be float or int, not ' + str(type(reverberance)))
+        raise PyAudacityException(
+            "reverberance argument must be float or int, not " + str(type(reverberance))
+        )
     if not isinstance(hf_damping, (float, int)):
-        raise PyAudacityException('hf_damping argument must be float or int, not ' + str(type(hf_damping)))
+        raise PyAudacityException(
+            "hf_damping argument must be float or int, not " + str(type(hf_damping))
+        )
     if not isinstance(tone_low, (float, int)):
-        raise PyAudacityException('tone_low argument must be float or int, not ' + str(type(tone_low)))
+        raise PyAudacityException(
+            "tone_low argument must be float or int, not " + str(type(tone_low))
+        )
     if not isinstance(tone_high, (float, int)):
-        raise PyAudacityException('tone_high argument must be float or int, not ' + str(type(tone_high)))
+        raise PyAudacityException(
+            "tone_high argument must be float or int, not " + str(type(tone_high))
+        )
     if not isinstance(wet_gain, (float, int)):
-        raise PyAudacityException('wet_gain argument must be float or int, not ' + str(type(wet_gain)))
+        raise PyAudacityException(
+            "wet_gain argument must be float or int, not " + str(type(wet_gain))
+        )
     if not isinstance(dry_gain, (float, int)):
-        raise PyAudacityException('dry_gain argument must be float or int, not ' + str(type(dry_gain)))
+        raise PyAudacityException(
+            "dry_gain argument must be float or int, not " + str(type(dry_gain))
+        )
     if not isinstance(stereo_width, (float, int)):
-        raise PyAudacityException('stereo_width argument must be float or int, not ' + str(type(stereo_width)))
+        raise PyAudacityException(
+            "stereo_width argument must be float or int, not " + str(type(stereo_width))
+        )
     if not isinstance(wet_only, bool):
-        raise PyAudacityException('wet_only argument must be a bool, not' + str(type(wet_only)))
+        raise PyAudacityException(
+            "wet_only argument must be a bool, not" + str(type(wet_only))
+        )
 
     return do(
         'Reverb: RoomSize="{}" Delay="{}" Reverberance="{}" HfDamping="{}" ToneLow="{}" ToneHigh="{}" WetGain="{}" DryGain="{}" StereoWidth="{}" WetOnly="{}"'.format(
-            room_size, delay, reverberance, hf_damping, tone_low, tone_high, wet_gain, dry_gain, stereo_width, wet_only
+            room_size,
+            delay,
+            reverberance,
+            hf_damping,
+            tone_low,
+            tone_high,
+            wet_gain,
+            dry_gain,
+            stereo_width,
+            wet_only,
         )
     )
 
@@ -2262,7 +2571,7 @@ def reverse():
     Audacity Documentation: Reverses the selected audio; after the effect the end of the audio will be heard first and the beginning last.
     """
 
-    return do('Reverse')
+    return do("Reverse")
 
 
 def sliding_stretch(
@@ -2281,27 +2590,33 @@ def sliding_stretch(
 
     if not isinstance(rate_percent_change_start, (float, int)):
         raise PyAudacityException(
-            'rate_percent_change_start argument must be float or int, not ' + str(type(rate_percent_change_start))
+            "rate_percent_change_start argument must be float or int, not "
+            + str(type(rate_percent_change_start))
         )
     if not isinstance(rate_percent_change_end, (float, int)):
         raise PyAudacityException(
-            'rate_percent_change_end argument must be float or int, not ' + str(type(rate_percent_change_end))
+            "rate_percent_change_end argument must be float or int, not "
+            + str(type(rate_percent_change_end))
         )
     if not isinstance(pitch_half_steps_start, (float, int)):
         raise PyAudacityException(
-            'pitch_half_steps_start argument must be float or int, not ' + str(type(pitch_half_steps_start))
+            "pitch_half_steps_start argument must be float or int, not "
+            + str(type(pitch_half_steps_start))
         )
     if not isinstance(pitch_half_steps_end, (float, int)):
         raise PyAudacityException(
-            'pitch_half_steps_end argument must be float or int, not ' + str(type(pitch_half_steps_end))
+            "pitch_half_steps_end argument must be float or int, not "
+            + str(type(pitch_half_steps_end))
         )
     if not isinstance(pitch_percent_change_start, (float, int)):
         raise PyAudacityException(
-            'pitch_percent_change_start argument must be float or int, not ' + str(type(pitch_percent_change_start))
+            "pitch_percent_change_start argument must be float or int, not "
+            + str(type(pitch_percent_change_start))
         )
     if not isinstance(pitch_percent_change_end, (float, int)):
         raise PyAudacityException(
-            'pitch_percent_change_end argument must be float or int, not ' + str(type(pitch_percent_change_end))
+            "pitch_percent_change_end argument must be float or int, not "
+            + str(type(pitch_percent_change_end))
         )
 
     return do(
@@ -2316,7 +2631,14 @@ def sliding_stretch(
     )
 
 
-def truncate_silence(threshold=-20.0, action='Truncate', minimum=0.5, truncate=0.5, compress=50.0, independent=False):
+def truncate_silence(
+    threshold=-20.0,
+    action="Truncate",
+    minimum=0.5,
+    truncate=0.5,
+    compress=50.0,
+    independent=False,
+):
     # type: (float, str, float, float, float, bool) -> str
     """TODO
 
@@ -2324,16 +2646,26 @@ def truncate_silence(threshold=-20.0, action='Truncate', minimum=0.5, truncate=0
     """
 
     if not isinstance(threshold, (float, int)):
-        raise PyAudacityException('threshold argument must be float or int, not ' + str(type(threshold)))
+        raise PyAudacityException(
+            "threshold argument must be float or int, not " + str(type(threshold))
+        )
     # TODO action check
     if not isinstance(minimum, (float, int)):
-        raise PyAudacityException('minimum argument must be float or int, not ' + str(type(minimum)))
+        raise PyAudacityException(
+            "minimum argument must be float or int, not " + str(type(minimum))
+        )
     if not isinstance(truncate, (float, int)):
-        raise PyAudacityException('truncate argument must be float or int, not ' + str(type(truncate)))
+        raise PyAudacityException(
+            "truncate argument must be float or int, not " + str(type(truncate))
+        )
     if not isinstance(compress, (float, int)):
-        raise PyAudacityException('compress argument must be float or int, not ' + str(type(compress)))
+        raise PyAudacityException(
+            "compress argument must be float or int, not " + str(type(compress))
+        )
     if not isinstance(independent, bool):
-        raise PyAudacityException('independent argument must be a bool, not' + str(type(independent)))
+        raise PyAudacityException(
+            "independent argument must be a bool, not" + str(type(independent))
+        )
 
     return do(
         'TruncateSilence: Threshold="{}" Action="{}" Minimum="{}" Truncate="{}" Compress="{}" Independent="{}"'
@@ -2344,27 +2676,40 @@ def wahwah(freq=1.5, phase=0.0, depth=70, resonance=2.5, offset=30, gain=-6.0):
     # type: (float, float, int, float, int, float) -> str
     """TODO
 
-    Audacity Documentation: Rapid tone quality variations, like that guitar sound so popular in the 1970's."""
+    Audacity Documentation: Rapid tone quality variations, like that guitar sound so popular in the 1970's.
+    """
 
     if not isinstance(freq, (float, int)):
-        raise PyAudacityException('freq argument must be float or int, not ' + str(type(freq)))
+        raise PyAudacityException(
+            "freq argument must be float or int, not " + str(type(freq))
+        )
     if not isinstance(phase, (float, int)):
-        raise PyAudacityException('phase argument must be float or int, not ' + str(type(phase)))
+        raise PyAudacityException(
+            "phase argument must be float or int, not " + str(type(phase))
+        )
     if not isinstance(depth, int):
-        raise PyAudacityException('depth argument must be int, not ' + str(type(depth)))
+        raise PyAudacityException("depth argument must be int, not " + str(type(depth)))
     if not isinstance(resonance, (float, int)):
-        raise PyAudacityException('resonance argument must be float or int, not ' + str(type(resonance)))
+        raise PyAudacityException(
+            "resonance argument must be float or int, not " + str(type(resonance))
+        )
     if not isinstance(offset, int):
-        raise PyAudacityException('offset argument must be int, not ' + str(type(offset)))
+        raise PyAudacityException(
+            "offset argument must be int, not " + str(type(offset))
+        )
     if not isinstance(gain, (float, int)):
-        raise PyAudacityException('gain argument must be float or int, not ' + str(type(gain)))
+        raise PyAudacityException(
+            "gain argument must be float or int, not " + str(type(gain))
+        )
 
-    return do('Wahwah: Freq="{}" Phase="{}" Depth="{}" Resonance="{}" Offset="{}" Gain="{}"').format(
-        freq, phase, depth, resonance, offset, gain
-    )
+    return do(
+        'Wahwah: Freq="{}" Phase="{}" Depth="{}" Resonance="{}" Offset="{}" Gain="{}"'
+    ).format(freq, phase, depth, resonance, offset, gain)
 
 
-def adjustable_fade(fade_type='Up', curve=0.0, units='Percent', gain0=0, gain1=0, preset='None'):
+def adjustable_fade(
+    fade_type="Up", curve=0.0, units="Percent", gain0=0, gain1=0, preset="None"
+):
     # type: (str, float, str, float, float, str) -> str
     """TODO
 
@@ -2384,12 +2729,17 @@ def clip_fix(threshold=0.0, gain=0.0):
     # type: (float, float) -> str
     """TODO
 
-    Audacity Documentation: Clip Fix attempts to reconstruct clipped regions by interpolating the lost signal."""
+    Audacity Documentation: Clip Fix attempts to reconstruct clipped regions by interpolating the lost signal.
+    """
 
     if not isinstance(threshold, (float, int)):
-        raise PyAudacityException('threshold argument must be float or int, not ' + str(type(threshold)))
+        raise PyAudacityException(
+            "threshold argument must be float or int, not " + str(type(threshold))
+        )
     if not isinstance(gain, (float, int)):
-        raise PyAudacityException('gain argument must be float or int, not ' + str(type(gain)))
+        raise PyAudacityException(
+            "gain argument must be float or int, not " + str(type(gain))
+        )
 
     return do('ClipFix: threshold="{}" gain="{}"'.format(threshold, gain))
 
@@ -2401,10 +2751,10 @@ def crossfade_clips():
     Audacity Documentation: Use Crossfade Clips to apply a simple crossfade to a selected pair of clips in a single audio track.
     """
 
-    return do('CrossfadeClips')
+    return do("CrossfadeClips")
 
 
-def crossfade_tracks(xfade_type='ConstantGain', curve=0.0, direction='Automatic'):
+def crossfade_tracks(xfade_type="ConstantGain", curve=0.0, direction="Automatic"):
     # type: (str, float, str) -> str
     """TODO
 
@@ -2412,14 +2762,27 @@ def crossfade_tracks(xfade_type='ConstantGain', curve=0.0, direction='Automatic'
     """
 
     # TODO - add param checks
-    return do('CrossfadeTracks: type="{}" curve="{}" direction="{}"'.format(xfade_type, curve, direction))
+    return do(
+        'CrossfadeTracks: type="{}" curve="{}" direction="{}"'.format(
+            xfade_type, curve, direction
+        )
+    )
 
 
-def delay(delay_type='Regular', d_gain=0.0, delay=0.0, pitch_type='PitchTempo', shift=0.0, number=0, constrain='Yes'):
+def delay(
+    delay_type="Regular",
+    d_gain=0.0,
+    delay=0.0,
+    pitch_type="PitchTempo",
+    shift=0.0,
+    number=0,
+    constrain="Yes",
+):
     # type: (str, float, float, str, float, int, str) -> str
     """TODO
 
-    Audacity Documentation: A configurable delay effect with variable delay time and pitch shifting of the delays."""
+    Audacity Documentation: A configurable delay effect with variable delay time and pitch shifting of the delays.
+    """
 
     # TODO - add param checks
 
@@ -2430,17 +2793,21 @@ def delay(delay_type='Regular', d_gain=0.0, delay=0.0, pitch_type='PitchTempo', 
     )
 
 
-def high_pass_filter(frequency=0.0, roll_off='dB6'):
+def high_pass_filter(frequency=0.0, roll_off="dB6"):
     # type: (float, str) -> str
     """TODO
 
     Audacity Documentation: Passes frequencies above its cutoff frequency and attenuates frequencies below its cutoff frequency.
     """
 
-    return do('High-passFilter: frequency="{}" rolloff="{}"'.format(frequency, roll_off))
+    return do(
+        'High-passFilter: frequency="{}" rolloff="{}"'.format(frequency, roll_off)
+    )
 
 
-def limiter(limiter_type='SoftLimit', gain_left=0, gain_right=0, limit=0, hold=0, makeup='No'):
+def limiter(
+    limiter_type="SoftLimit", gain_left=0, gain_right=0, limit=0, hold=0, makeup="No"
+):
     # type: (str, float, float, float, float, str) -> str
     """TODO
 
@@ -2454,7 +2821,7 @@ def limiter(limiter_type='SoftLimit', gain_left=0, gain_right=0, limit=0, hold=0
     )
 
 
-def low_pass_filter(frequency=0.0, roll_off='db6'):
+def low_pass_filter(frequency=0.0, roll_off="db6"):
     # type: (float, str) -> str
     """TODO
 
@@ -2472,9 +2839,13 @@ def notch_filter(frequency=0.0, q=0.0):
     """
 
     if not isinstance(frequency, (float, int)):
-        raise PyAudacityException('frequency argument must be float or int, not ' + str(type(frequency)))
+        raise PyAudacityException(
+            "frequency argument must be float or int, not " + str(type(frequency))
+        )
     if not isinstance(q, (float, int)):
-        raise PyAudacityException('q argument must be float or int, not ' + str(type(q)))
+        raise PyAudacityException(
+            "q argument must be float or int, not " + str(type(q))
+        )
 
     return do('NotchFilter: frequency="{}" q="{}"').format(frequency, q)
 
@@ -2485,7 +2856,7 @@ def spectral_edit_multi_tool():
 
     Audacity Documentation: When the selected track is in spectrogram or spectrogram log(f) view, applies a notch filter, high pass filter or low pass filter according to the spectral selection made. This effect can also be used to change the audio quality as an alternative to using Equalization.
     """
-    return do('SpectralEditMultiTool')
+    return do("SpectralEditMultiTool")
 
 
 def spectral_edit_parametric_eq(control_gain=0.0):
@@ -2496,7 +2867,9 @@ def spectral_edit_parametric_eq(control_gain=0.0):
     """
 
     if not isinstance(control_gain, (float, int)):
-        raise PyAudacityException('control_gain argument must be float or int, not ' + str(type(control_gain)))
+        raise PyAudacityException(
+            "control_gain argument must be float or int, not " + str(type(control_gain))
+        )
 
     # TODO - double check other macros for parameter names with dashes.
     return do('SpectralEditParametricEq: control-gain="{}"').format(control_gain)
@@ -2510,7 +2883,9 @@ def spectral_edit_shelves(control_gain=0.0):
     """
 
     if not isinstance(control_gain, (float, int)):
-        raise PyAudacityException('control_gain argument must be float or int, not ' + str(type(control_gain)))
+        raise PyAudacityException(
+            "control_gain argument must be float or int, not " + str(type(control_gain))
+        )
 
     return do('SpectralEditShelves: control-gain="{}"').format(control_gain)
 
@@ -2522,10 +2897,10 @@ def studio_fade_out():
     Audacity Documentation: Applies a more musical fade out to the selected audio, giving a more pleasing sounding result.
     """
 
-    return do('StudioFadeOut')
+    return do("StudioFadeOut")
 
 
-def tremolo(wave='Sine', phase=0, wet=0, lfo=0.0):
+def tremolo(wave="Sine", phase=0, wet=0, lfo=0.0):
     # type: (str, int, int, float) -> str
     """TODO
 
@@ -2539,16 +2914,22 @@ def tremolo(wave='Sine', phase=0, wet=0, lfo=0.0):
     # TODO in the Tremolo dialog, lfo is labeled "Frequency". What's the correct name?
 
     if not isinstance(phase, int):
-        raise PyAudacityException('phase argument must be int, not ' + str(type(phase)))
+        raise PyAudacityException("phase argument must be int, not " + str(type(phase)))
     if not isinstance(wet, int):
-        raise PyAudacityException('wet argument must be int, not ' + str(type(wet)))
+        raise PyAudacityException("wet argument must be int, not " + str(type(wet)))
     if not isinstance(lfo, (float, int)):
-        raise PyAudacityException('lfo argument must be float or int, not ' + str(type(lfo)))
+        raise PyAudacityException(
+            "lfo argument must be float or int, not " + str(type(lfo))
+        )
 
-    return do('Tremolo: wave="{}" phase="{}" wet="{}" lfo="{}"').format(wave, phase, wet, lfo)
+    return do('Tremolo: wave="{}" phase="{}" wet="{}" lfo="{}"').format(
+        wave, phase, wet, lfo
+    )
 
 
-def vocal_reduction_and_isolation(action='RemoveToMono', strength=0.0, low_transition=0.0, high_transition=0.0):
+def vocal_reduction_and_isolation(
+    action="RemoveToMono", strength=0.0, low_transition=0.0, high_transition=0.0
+):
     # type: (str, float, float, float) -> str
     """TODO
 
@@ -2558,18 +2939,34 @@ def vocal_reduction_and_isolation(action='RemoveToMono', strength=0.0, low_trans
     # TODO check action
 
     if not isinstance(strength, (float, int)):
-        raise PyAudacityException('strength argument must be float or int, not ' + str(type(strength)))
+        raise PyAudacityException(
+            "strength argument must be float or int, not " + str(type(strength))
+        )
     if not isinstance(low_transition, (float, int)):
-        raise PyAudacityException('low_transition argument must be float or int, not ' + str(type(low_transition)))
+        raise PyAudacityException(
+            "low_transition argument must be float or int, not "
+            + str(type(low_transition))
+        )
     if not isinstance(high_transition, (float, int)):
-        raise PyAudacityException('high_transition argument must be float or int, not ' + str(type(high_transition)))
+        raise PyAudacityException(
+            "high_transition argument must be float or int, not "
+            + str(type(high_transition))
+        )
 
     return do('TODO: strength="{}" low_transition="{}" high_transition="{}"').format(
         strength, low_transition, high_transition
     )
 
 
-def vocoder(dst=0.0, mst='BothChannels', bands=0, track_vl=0.0, noise_vl=0.0, radar_vl=0.0, radar_f=0.0):
+def vocoder(
+    dst=0.0,
+    mst="BothChannels",
+    bands=0,
+    track_vl=0.0,
+    noise_vl=0.0,
+    radar_vl=0.0,
+    radar_f=0.0,
+):
     # type: (float, str, int, float, float, float, float) -> str
     """TODO
 
@@ -2577,22 +2974,32 @@ def vocoder(dst=0.0, mst='BothChannels', bands=0, track_vl=0.0, noise_vl=0.0, ra
     """
 
     if not isinstance(dst, (float, int)):
-        raise PyAudacityException('dst argument must be float or int, not ' + str(type(dst)))
+        raise PyAudacityException(
+            "dst argument must be float or int, not " + str(type(dst))
+        )
     # TODO check mst
     if not isinstance(bands, int):
-        raise PyAudacityException('bands argument must be int, not ' + str(type(bands)))
+        raise PyAudacityException("bands argument must be int, not " + str(type(bands)))
     if not isinstance(track_vl, (float, int)):
-        raise PyAudacityException('track_vl argument must be float or int, not ' + str(type(track_vl)))
+        raise PyAudacityException(
+            "track_vl argument must be float or int, not " + str(type(track_vl))
+        )
     if not isinstance(noise_vl, (float, int)):
-        raise PyAudacityException('noise_vl argument must be float or int, not ' + str(type(noise_vl)))
+        raise PyAudacityException(
+            "noise_vl argument must be float or int, not " + str(type(noise_vl))
+        )
     if not isinstance(radar_vl, (float, int)):
-        raise PyAudacityException('radar_vl argument must be float or int, not ' + str(type(radar_vl)))
+        raise PyAudacityException(
+            "radar_vl argument must be float or int, not " + str(type(radar_vl))
+        )
     if not isinstance(radar_f, (float, int)):
-        raise PyAudacityException('radar_f argument must be float or int, not ' + str(type(radar_f)))
+        raise PyAudacityException(
+            "radar_f argument must be float or int, not " + str(type(radar_f))
+        )
 
-    return do('TODO: dst="{}" mst="{}" bands="{}" track-vl="{}" noise-vl="{}" radar-vl="{}" radar-f="{}"').format(
-        dst, mst, bands, track_vl, noise_vl, radar_vl, radar_f
-    )
+    return do(
+        'TODO: dst="{}" mst="{}" bands="{}" track-vl="{}" noise-vl="{}" radar-vl="{}" radar-f="{}"'
+    ).format(dst, mst, bands, track_vl, noise_vl, radar_vl, radar_f)
 
 
 # NOTE THE SPELLING OF "ANALYZERS"
@@ -2602,7 +3009,7 @@ def manage_analyzers():
 
     Audacity Documentation: Selecting this option from the Effect Menu (or the Generate Menu or Analyze Menu) takes you to a dialog where you can enable or disable particular Effects, Generators and Analyzers in Audacity. Even if you do not add any third-party plugins, you can use this to make the Effect menu shorter or longer as required. For details see Plugin Manager.
     """
-    return do('ManageAnalyzers')
+    return do("ManageAnalyzers")
 
 
 # NOTE THE SPELLING OF "ANALYSER"
@@ -2612,7 +3019,7 @@ def contrast_analyser():
 
     Audacity Documentation: Analyzes a single mono or stereo speech track to determine the average RMS difference in volume (contrast) between foreground speech and background music, audience noise or similar. The purpose is to determine if the speech will be intelligible to the hard of hearing.
     """
-    return do('ConrastAnalyser')
+    return do("ConrastAnalyser")
 
 
 def plot_spectrum():
@@ -2621,7 +3028,7 @@ def plot_spectrum():
 
     Audacity Documentation: Takes the selected audio (which is a set of sound pressure values at points in time) and converts it to a graph of frequencies against amplitudes.
     """
-    return do('PlotSpectrum')
+    return do("PlotSpectrum")
 
 
 def find_clipping(duty_cycle_start=3, duty_cycle_end=3):
@@ -2634,11 +3041,17 @@ def find_clipping(duty_cycle_start=3, duty_cycle_end=3):
     # TODO Parameter names in documentation have spaces, double check
 
     if not isinstance(duty_cycle_start, int):
-        raise PyAudacityException('duty_cycle_start argument must be int, not ' + str(type(duty_cycle_start)))
+        raise PyAudacityException(
+            "duty_cycle_start argument must be int, not " + str(type(duty_cycle_start))
+        )
     if not isinstance(duty_cycle_end, int):
-        raise PyAudacityException('duty_cycle_end argument must be int, not ' + str(type(duty_cycle_end)))
+        raise PyAudacityException(
+            "duty_cycle_end argument must be int, not " + str(type(duty_cycle_end))
+        )
 
-    return do('FindClipping: DutyCycleStart="{}" DutyCycleEnd="{}"').format(duty_cycle_start, duty_cycle_end)
+    return do('FindClipping: DutyCycleStart="{}" DutyCycleEnd="{}"').format(
+        duty_cycle_start, duty_cycle_end
+    )
 
 
 def beat_finder(thresval=0):
@@ -2649,25 +3062,28 @@ def beat_finder(thresval=0):
     """
 
     if not isinstance(thresval, int):
-        raise PyAudacityException('thresval argument must be int, not ' + str(type(thresval)))
+        raise PyAudacityException(
+            "thresval argument must be int, not " + str(type(thresval))
+        )
 
     return do('BeatFinder: thresval="{}"').format(thresval)
 
 
 def label_sounds(
     thershold_level=-30,
-    threshold_measurement='Peak level',
+    threshold_measurement="Peak level",
     min_silence_duration=0,
     min_label_interval=0,
-    label_type='Point before sound',
+    label_type="Point before sound",
     max_leading_silence=0,
     max_trailing_silence=0,
-    label_text='Sound ##1',
+    label_text="Sound ##1",
 ):
     # type: (float, str, float, float, str, float, float, str) -> str
     """TODO
 
-    Audacity Documentation: Divides up a track by placing labels for areas of sound that are separated by silence."""
+    Audacity Documentation: Divides up a track by placing labels for areas of sound that are separated by silence.
+    """
 
     return do(
         'LabelSounds: threshold="{}" measurement="{}" sil-dur="{}" snd-dur="{}" type="{}" pre-offset="{}" post-offset="{}" text="{}"'.format(
@@ -2690,7 +3106,7 @@ def manage_tools():
     Audacity Documentation: Selecting this option from the Effect Menu (or the Generate Menu or Analyze Menu) takes you to a dialog where you can enable or disable particular Effects, Generators and Analyzers in Audacity. Even if you do not add any third-party plugins, you can use this to make the Effect menu shorter or longer as required. For details see Plugin Manager.
     """
 
-    return do('ManageTools')
+    return do("ManageTools")
 
 
 def manage_macros():
@@ -2699,7 +3115,7 @@ def manage_macros():
 
     Audacity Documentation: Creates a new macro or edits an existing macro."""
 
-    return do('ManageMacros')
+    return do("ManageMacros")
 
 
 def apply_macro():
@@ -2710,13 +3126,19 @@ def apply_macro():
     """
 
     # TODO - documentation shows "Apply Macro" as the name, with a space. I assume this is wrong and remove the space:
-    return do('ApplyMacro')
+    return do("ApplyMacro")
 
 
-def screenshot(save_images_to_folder=Path.home(), capture='Window Only', background='None', to_top=True):
+def screenshot(
+    save_images_to_folder=Path.home(),
+    capture="Window Only",
+    background="None",
+    to_top=True,
+):
     """TODO
 
-    Audacity Documentation: A tool, mainly used in documentation, to capture screenshots of Audacity."""
+    Audacity Documentation: A tool, mainly used in documentation, to capture screenshots of Audacity.
+    """
 
     # TODO - find out what "ToTop" parameter is for. The docs don't say and it doesn't appear in the UI.
     raise NotImplementedError
@@ -2725,12 +3147,13 @@ def screenshot(save_images_to_folder=Path.home(), capture='Window Only', backgro
 def benchmark():
     """Opens the Tools > Run Benchmark dialog.
 
-    Audacity Documentation: A tool for measuring the performance of one part of Audacity."""
+    Audacity Documentation: A tool for measuring the performance of one part of Audacity.
+    """
 
-    return do('Benchmark')
+    return do("Benchmark")
 
 
-def nyquist_prompt(command='', version=3):
+def nyquist_prompt(command="", version=3):
     # type: (str, int) -> str
     """TODO
 
@@ -2738,60 +3161,84 @@ def nyquist_prompt(command='', version=3):
     """
 
     if not isinstance(command, str):
-        raise PyAudacityException('command argument must be str, not ' + str(type(command)))
+        raise PyAudacityException(
+            "command argument must be str, not " + str(type(command))
+        )
     if not isinstance(version, int):
-        raise PyAudacityException('version argument must be int, not ' + str(type(version)))
+        raise PyAudacityException(
+            "version argument must be int, not " + str(type(version))
+        )
 
     return do('NyquistPrompt: Command="{}" Version="{}"').format(command, version)
 
 
-def nyquist_plugin_installer(files="", overwrite='Disallow'):
+def nyquist_plugin_installer(files="", overwrite="Disallow"):
     """TODO
 
-    Audacity Documentation: A Nyquist plugin that simplifies the installation of other Nyquist plugins."""
+    Audacity Documentation: A Nyquist plugin that simplifies the installation of other Nyquist plugins.
+    """
     raise NotImplementedError
 
 
 def regular_interval_labels(
-    mode='Both',
+    mode="Both",
     total_num=0,
     interval=0.0,
     region=0.0,
-    adjust='No',
-    label_text='',
-    zeros='TextOnly',
+    adjust="No",
+    label_text="",
+    zeros="TextOnly",
     first_number=0,
-    verbose='Details',
+    verbose="Details",
 ):
     # type: (str, int, float, float, str, str, str, int, str) -> str
     """TODO
 
-    Audacity Documentation: Places labels in a long track so as to divide it into smaller, equally sized segments."""
+    Audacity Documentation: Places labels in a long track so as to divide it into smaller, equally sized segments.
+    """
 
     # TODO check mode, adjust, label_text, zeros, verbose
     if not isinstance(total_num, int):
-        raise PyAudacityException('total_num argument must be int, not ' + str(type(total_num)))
+        raise PyAudacityException(
+            "total_num argument must be int, not " + str(type(total_num))
+        )
     if not isinstance(interval, (float, int)):
-        raise PyAudacityException('interval argument must be float or int, not ' + str(type(interval)))
+        raise PyAudacityException(
+            "interval argument must be float or int, not " + str(type(interval))
+        )
     if not isinstance(region, (float, int)):
-        raise PyAudacityException('region argument must be float or int, not ' + str(type(region)))
+        raise PyAudacityException(
+            "region argument must be float or int, not " + str(type(region))
+        )
     if not isinstance(first_number, int):
-        raise PyAudacityException('first_number argument must be int, not ' + str(type(first_number)))
+        raise PyAudacityException(
+            "first_number argument must be int, not " + str(type(first_number))
+        )
 
     return do(
         'RegularIntervalLabels: mode="{}" totalnum="{}" interval="{}" region="{}" adjust="{}" labeltext="{}" zeros="{}" firstnum="{}" verbose="{}"'
-    ).format(mode, total_num, interval, region, adjust, label_text, zeros, first_number, verbose)
+    ).format(
+        mode,
+        total_num,
+        interval,
+        region,
+        adjust,
+        label_text,
+        zeros,
+        first_number,
+        verbose,
+    )
 
 
 def sample_data_export(
     export_filename,
     limit_output_to_first=100,
-    measurement_scale='dB',
-    index_format='None',
-    include_header_information='None',
-    optional_header_text='',
-    channel_layout_for_stereo='L-R on Same Line',
-    show_messages='Yes',
+    measurement_scale="dB",
+    index_format="None",
+    include_header_information="None",
+    optional_header_text="",
+    channel_layout_for_stereo="L-R on Same Line",
+    show_messages="Yes",
 ):
     # type: (Union[Path, str], int, str, str, str, str, str, str) -> str
     """TODO
@@ -2815,7 +3262,7 @@ def sample_data_export(
     )
 
 
-def sample_data_import(import_filename, invalid_data_handling='Throw Error'):
+def sample_data_import(import_filename, invalid_data_handling="Throw Error"):
     # type: (Union[Path, str], str) -> str
     """TODO
 
@@ -2830,15 +3277,16 @@ def apply_macros_palette():
 
     Audacity Documentation: Displays a menu with list of all your Macros which can be applied to the current project or to audio files.
     """
-    return do('ApplyMacrosPalette')
+    return do("ApplyMacrosPalette")
 
 
 def macro_fade_ends():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Fades in the first second and fades out the last second of a track."""
-    return do('Macro_FadeEnds')
+    Audacity Documentation: Fades in the first second and fades out the last second of a track.
+    """
+    return do("Macro_FadeEnds")
 
 
 def macro_mp3_conversion():
@@ -2846,7 +3294,7 @@ def macro_mp3_conversion():
     """TODO
 
     Audacity Documentation: Converts MP3."""
-    return do('Macro_MP3Conversion')
+    return do("Macro_MP3Conversion")
 
 
 def full_screen_on_off():
@@ -2854,7 +3302,7 @@ def full_screen_on_off():
     """TODO
 
     Audacity Documentation: Toggle full screen mode with no title bar."""
-    return do('FullScreenOnOff')
+    return do("FullScreenOnOff")
 
 
 def play():
@@ -2862,7 +3310,7 @@ def play():
     """TODO
 
     Audacity Documentation: Play (or stop) audio."""
-    return do('Play')
+    return do("Play")
 
 
 def stop():
@@ -2870,7 +3318,7 @@ def stop():
     """TODO
 
     Audacity Documentation: Stop audio."""
-    return do('Stop')
+    return do("Stop")
 
 
 def play_one_sec():
@@ -2879,7 +3327,7 @@ def play_one_sec():
 
     Audacity Documentation: Plays for one second centered on the current mouse pointer position (not from the current cursor position). See this page for an example.
     """
-    return do('PlayOneSec')
+    return do("PlayOneSec")
 
 
 def play_to_selection():
@@ -2888,7 +3336,7 @@ def play_to_selection():
 
     Audacity Documentation: Plays to or from the current mouse pointer position to or from the start or end of the selection, depending on the pointer position. See this page for more details.
     """
-    return do('PlayToSelection')
+    return do("PlayToSelection")
 
 
 def play_before_selection_start():
@@ -2897,7 +3345,7 @@ def play_before_selection_start():
 
     Audacity Documentation: Plays a short period before the start of the selected audio, the period before shares the setting of the cut preview.
     """
-    return do('PlayBeforeSelectionStart')
+    return do("PlayBeforeSelectionStart")
 
 
 def play_after_selection_start():
@@ -2906,7 +3354,7 @@ def play_after_selection_start():
 
     Audacity Documentation: Plays a short period after the start of the selected audio, the period after shares the setting of the cut preview.
     """
-    return do('PlayAfterSelectionStart')
+    return do("PlayAfterSelectionStart")
 
 
 def play_before_selection_end():
@@ -2915,7 +3363,7 @@ def play_before_selection_end():
 
     Audacity Documentation: Plays a short period before the end of the selected audio, the period before shares the setting of the cut preview.
     """
-    return do('PlayBeforeSelectionEnd')
+    return do("PlayBeforeSelectionEnd")
 
 
 def play_after_selection_end():
@@ -2924,7 +3372,7 @@ def play_after_selection_end():
 
     Audacity Documentation: Plays a short period after the end of the selected audio, the period after shares the setting of the cut preview.
     """
-    return do('PlayAfterSelectionEnd')
+    return do("PlayAfterSelectionEnd")
 
 
 def play_before_and_after_selection_start():
@@ -2933,7 +3381,7 @@ def play_before_and_after_selection_start():
 
     Audacity Documentation: Plays a short period before and after the start of the selected audio, the periods before and after share the setting of the cut preview.
     """
-    return do('PlayBeforeAndAfterSelectionStart')
+    return do("PlayBeforeAndAfterSelectionStart")
 
 
 def play_before_and_after_selection_end():
@@ -2942,7 +3390,7 @@ def play_before_and_after_selection_end():
 
     Audacity Documentation: Plays a short period before and after the end of the selected audio, the periods before and after share the setting of the cut preview.
     """
-    return do('PlayBeforeAndAfterSelectionEnd')
+    return do("PlayBeforeAndAfterSelectionEnd")
 
 
 def play_cut_preview():
@@ -2950,7 +3398,7 @@ def play_cut_preview():
     """TODO
 
     Audacity Documentation: Plays audio excluding the selection."""
-    return do('PlayCutPreview')
+    return do("PlayCutPreview")
 
 
 def select_tool():
@@ -2958,7 +3406,7 @@ def select_tool():
     """TODO
 
     Audacity Documentation: Chooses Selection tool."""
-    return do('SelectTool')
+    return do("SelectTool")
 
 
 def envelope_tool():
@@ -2966,7 +3414,7 @@ def envelope_tool():
     """TODO
 
     Audacity Documentation: Chooses Envelope tool."""
-    return do('EnvelopeTool')
+    return do("EnvelopeTool")
 
 
 def draw_tool():
@@ -2974,7 +3422,7 @@ def draw_tool():
     """TODO
 
     Audacity Documentation: Chooses Draw tool."""
-    return do('DrawTool')
+    return do("DrawTool")
 
 
 def zoom_tool():
@@ -2982,7 +3430,7 @@ def zoom_tool():
     """TODO
 
     Audacity Documentation: Chooses Zoom tool."""
-    return do('ZoomTool')
+    return do("ZoomTool")
 
 
 def multi_tool():
@@ -2990,7 +3438,7 @@ def multi_tool():
     """TODO
 
     Audacity Documentation: Chooses the Multi-Tool."""
-    return do('MultiTool')
+    return do("MultiTool")
 
 
 def prev_tool():
@@ -2999,7 +3447,7 @@ def prev_tool():
 
     Audacity Documentation: Cycles backwards through the tools, starting from the currently selected tool:  # type: () -> str starting from Selection, it would navigate to Multi-tool to Time Shift to Zoom to Draw to Envelope to Selection.
     """
-    return do('PrevTool')
+    return do("PrevTool")
 
 
 def next_tool():
@@ -3008,7 +3456,7 @@ def next_tool():
 
     Audacity Documentation: Cycles forwards through the tools, starting from the currently selected tool:  # type: () -> str starting from Selection, it would navigate to Envelope to Draw to Zoom to Time Shift to Multi-tool to Selection.
     """
-    return do('NextTool')
+    return do("NextTool")
 
 
 def output_gain():
@@ -3017,7 +3465,7 @@ def output_gain():
 
     Audacity Documentation: Displays the Playback Volume dialog. You can type a new value for the playback volume (between 0 and 1), or press Tab, then use the left and right arrow keys to adjust the slider.
     """
-    return do('OutputGain')
+    return do("OutputGain")
 
 
 def output_gain_inc():
@@ -3025,7 +3473,7 @@ def output_gain_inc():
     """TODO
 
     Audacity Documentation: Each key press will increase the playback volume by 0.1."""
-    return do('OutputGainInc')
+    return do("OutputGainInc")
 
 
 def output_gain_dec():
@@ -3033,7 +3481,7 @@ def output_gain_dec():
     """TODO
 
     Audacity Documentation: Each key press will decrease the playback volume by 0.1."""
-    return do('OutputGainDec')
+    return do("OutputGainDec")
 
 
 def input_gain():
@@ -3042,7 +3490,7 @@ def input_gain():
 
     Audacity Documentation: Displays the Recording Volume dialog. You can type a new value for the recording volume (between 0 and 1), or press Tab, then use the left and right arrow keys to adjust the slider.
     """
-    return do('InputGain')
+    return do("InputGain")
 
 
 def input_gain_inc():
@@ -3050,7 +3498,7 @@ def input_gain_inc():
     """TODO
 
     Audacity Documentation: Each key press will increase the recording volume by 0.1."""
-    return do('InputGainInc')
+    return do("InputGainInc")
 
 
 def input_gain_dec():
@@ -3058,7 +3506,7 @@ def input_gain_dec():
     """TODO
 
     Audacity Documentation: Each key press will decrease the recording volume by 0.1."""
-    return do('InputGainDec')
+    return do("InputGainDec")
 
 
 def delete_key():
@@ -3067,7 +3515,7 @@ def delete_key():
 
     Audacity Documentation: Deletes the selection. When focus is in Selection Toolbar, BACKSPACE is not a shortcut but navigates back to the previous digit and sets it to zero.
     """
-    return do('DeleteKey')
+    return do("DeleteKey")
 
 
 def delete_key2():
@@ -3075,7 +3523,7 @@ def delete_key2():
     """TODO
 
     Audacity Documentation: Deletes the selection."""
-    return do('DeleteKey2')
+    return do("DeleteKey2")
 
 
 def play_at_speed():
@@ -3083,7 +3531,7 @@ def play_at_speed():
     """TODO
 
     Audacity Documentation: Play audio at a faster or slower speed."""
-    return do('PlayAtSpeed')
+    return do("PlayAtSpeed")
 
 
 def play_at_speed_looped():
@@ -3091,7 +3539,7 @@ def play_at_speed_looped():
     """TODO
 
     Audacity Documentation: Combines looped play and play at speed."""
-    return do('PlayAtSpeedLooped')
+    return do("PlayAtSpeedLooped")
 
 
 def play_at_speed_cut_preview():
@@ -3099,7 +3547,7 @@ def play_at_speed_cut_preview():
     """TODO
 
     Audacity Documentation: Combines cut preview and play at speed."""
-    return do('PlayAtSpeedCutPreview')
+    return do("PlayAtSpeedCutPreview")
 
 
 def set_play_speed():
@@ -3108,7 +3556,7 @@ def set_play_speed():
 
     Audacity Documentation: Displays the Playback Speed dialog. You can type a new value for the playback volume (between 0 and 1), or press Tab, then use the left and right arrow keys to adjust the slider.
     """
-    return do('SetPlaySpeed')
+    return do("SetPlaySpeed")
 
 
 def play_speed_inc():
@@ -3116,7 +3564,7 @@ def play_speed_inc():
     """TODO
 
     Audacity Documentation: Each key press will increase the playback speed by 0.1."""
-    return do('PlaySpeedInc')
+    return do("PlaySpeedInc")
 
 
 def play_speed_dec():
@@ -3124,7 +3572,7 @@ def play_speed_dec():
     """TODO
 
     Audacity Documentation: Each key press will decrease the playback speed by 0.1."""
-    return do('PlaySpeedDec')
+    return do("PlaySpeedDec")
 
 
 def move_to_prev_label():
@@ -3132,7 +3580,7 @@ def move_to_prev_label():
     """TODO
 
     Audacity Documentation: Moves selection to the previous label."""
-    return do('MoveToPrevLabel')
+    return do("MoveToPrevLabel")
 
 
 def move_to_next_label():
@@ -3140,7 +3588,7 @@ def move_to_next_label():
     """TODO
 
     Audacity Documentation: Moves selection to the next label."""
-    return do('MoveToNextLabel')
+    return do("MoveToNextLabel")
 
 
 def seek_left_short():
@@ -3148,7 +3596,7 @@ def seek_left_short():
     """TODO
 
     Audacity Documentation: Skips the playback cursor back one second by default."""
-    return do('SeekLeftShort')
+    return do("SeekLeftShort")
 
 
 def seek_right_short():
@@ -3156,7 +3604,7 @@ def seek_right_short():
     """TODO
 
     Audacity Documentation: Skips the playback cursor forward one second by default."""
-    return do('SeekRightShort')
+    return do("SeekRightShort")
 
 
 def seek_left_long():
@@ -3164,7 +3612,7 @@ def seek_left_long():
     """TODO
 
     Audacity Documentation: Skips the playback cursor back 15 seconds by default."""
-    return do('SeekLeftLong')
+    return do("SeekLeftLong")
 
 
 def seek_right_long():
@@ -3172,7 +3620,7 @@ def seek_right_long():
     """TODO
 
     Audacity Documentation: Skips the playback cursor forward 15 seconds by default."""
-    return do('SeekRightLong')
+    return do("SeekRightLong")
 
 
 def input_device():
@@ -3181,7 +3629,7 @@ def input_device():
 
     Audacity Documentation: Displays the Select recording Device dialog for choosing the recording device, but only if the "Recording Device" dropdown menu in Device Toolbar has entries for devices. Otherwise, an recording error message will be displayed.
     """
-    return do('InputDevice')
+    return do("InputDevice")
 
 
 def output_device():
@@ -3190,7 +3638,7 @@ def output_device():
 
     Audacity Documentation: Displays the Select Playback Device dialog for choosing the playback device, but only if the "Playback Device" dropdown menu in Device Toolbar has entries for devices. Otherwise, an error message will be displayed.
     """
-    return do('OutputDevice')
+    return do("OutputDevice")
 
 
 def audio_host():
@@ -3199,7 +3647,7 @@ def audio_host():
 
     Audacity Documentation: Displays the Select Audio Host dialog for choosing the particular interface with which Audacity communicates with your chosen playback and recording devices.
     """
-    return do('AudioHost')
+    return do("AudioHost")
 
 
 def input_channels():
@@ -3208,31 +3656,34 @@ def input_channels():
 
     Audacity Documentation: Displays the Select Recording Channels dialog for choosing the number of channels to be recorded by the chosen recording device.
     """
-    return do('InputChannels')
+    return do("InputChannels")
 
 
 def snap_to_off():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Equivalent to setting the Snap To control in Selection Toolbar to "Off"."""
-    return do('SnapToOff')
+    Audacity Documentation: Equivalent to setting the Snap To control in Selection Toolbar to "Off".
+    """
+    return do("SnapToOff")
 
 
 def snap_to_nearest():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Equivalent to setting the Snap To control in Selection Toolbar to "Nearest"."""
-    return do('SnapToNearest')
+    Audacity Documentation: Equivalent to setting the Snap To control in Selection Toolbar to "Nearest".
+    """
+    return do("SnapToNearest")
 
 
 def snap_to_prior():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Equivalent to setting the Snap To control in Selection Toolbar to "Prior"."""
-    return do('SnapToPrior')
+    Audacity Documentation: Equivalent to setting the Snap To control in Selection Toolbar to "Prior".
+    """
+    return do("SnapToPrior")
 
 
 def sel_start():
@@ -3240,7 +3691,7 @@ def sel_start():
     """TODO
 
     Audacity Documentation: Select from cursor to start of track."""
-    return do('SelStart')
+    return do("SelStart")
 
 
 def sel_end():
@@ -3248,7 +3699,7 @@ def sel_end():
     """TODO
 
     Audacity Documentation: Select from cursor to end of track."""
-    return do('SelEnd')
+    return do("SelEnd")
 
 
 def sel_ext_left():
@@ -3257,7 +3708,7 @@ def sel_ext_left():
 
     Audacity Documentation: Increases the size of the selection by extending it to the left. The amount of increase is dependent on the zoom level. If there is no selection one is created starting at the cursor position.
     """
-    return do('SelExtLeft')
+    return do("SelExtLeft")
 
 
 def sel_ext_right():
@@ -3266,7 +3717,7 @@ def sel_ext_right():
 
     Audacity Documentation: Increases the size of the selection by extending it to the right. The amount of increase is dependent on the zoom level. If there is no selection one is created starting at the cursor position.
     """
-    return do('SelExtRight')
+    return do("SelExtRight")
 
 
 def sel_set_ext_left():
@@ -3274,7 +3725,7 @@ def sel_set_ext_left():
     """TODO
 
     Audacity Documentation: Extend selection left a little (is this a duplicate?)."""
-    return do('SelSetExtLeft')
+    return do("SelSetExtLeft")
 
 
 def sel_set_ext_right():
@@ -3282,7 +3733,7 @@ def sel_set_ext_right():
     """TODO
 
     Audacity Documentation: Extend selection right a litlle (is this a duplicate?)."""
-    return do('SelSetExtRight')
+    return do("SelSetExtRight")
 
 
 def sel_cntr_left():
@@ -3291,7 +3742,7 @@ def sel_cntr_left():
 
     Audacity Documentation: Decreases the size of the selection by contracting it from the right. The amount of decrease is dependent on the zoom level. If there is no selection no action is taken.
     """
-    return do('SelCntrLeft')
+    return do("SelCntrLeft")
 
 
 def sel_cntr_right():
@@ -3300,7 +3751,7 @@ def sel_cntr_right():
 
     Audacity Documentation: Decreases the size of the selection by contracting it from the left. The amount of decrease is dependent on the zoom level. If there is no selection no action is taken.
     """
-    return do('SelCntrRight')
+    return do("SelCntrRight")
 
 
 def prev_frame():
@@ -3309,7 +3760,7 @@ def prev_frame():
 
     Audacity Documentation: Move backward through currently focused toolbar in Upper Toolbar dock area, Track View and currently focused toolbar in Lower Toolbar dock area. Each use moves the keyboard focus as indicated.
     """
-    return do('PrevFrame')
+    return do("PrevFrame")
 
 
 def next_frame():
@@ -3318,7 +3769,7 @@ def next_frame():
 
     Audacity Documentation: Move forward through currently focused toolbar in Upper Toolbar dock area, Track View and currently focused toolbar in Lower Toolbar dock area. Each use moves the keyboard focus as indicated.
     """
-    return do('NextFrame')
+    return do("NextFrame")
 
 
 def prev_track():
@@ -3326,7 +3777,7 @@ def prev_track():
     """TODO
 
     Audacity Documentation: Focus one track up."""
-    return do('PrevTrack')
+    return do("PrevTrack")
 
 
 def next_track():
@@ -3334,7 +3785,7 @@ def next_track():
     """TODO
 
     Audacity Documentation: Focus one track down."""
-    return do('NextTrack')
+    return do("NextTrack")
 
 
 def first_track():
@@ -3342,7 +3793,7 @@ def first_track():
     """TODO
 
     Audacity Documentation: Focus on first track."""
-    return do('FirstTrack')
+    return do("FirstTrack")
 
 
 def last_track():
@@ -3350,7 +3801,7 @@ def last_track():
     """TODO
 
     Audacity Documentation: Focus on last track."""
-    return do('LastTrack')
+    return do("LastTrack")
 
 
 def shift_up():
@@ -3358,7 +3809,7 @@ def shift_up():
     """TODO
 
     Audacity Documentation: Focus one track up and select it."""
-    return do('ShiftUp')
+    return do("ShiftUp")
 
 
 def shift_down():
@@ -3366,7 +3817,7 @@ def shift_down():
     """TODO
 
     Audacity Documentation: Focus one track down and select it."""
-    return do('ShiftDown')
+    return do("ShiftDown")
 
 
 def toggle():
@@ -3374,7 +3825,7 @@ def toggle():
     """TODO
 
     Audacity Documentation: Toggle focus on current track."""
-    return do('Toggle')
+    return do("Toggle")
 
 
 def toggle_alt():
@@ -3382,7 +3833,7 @@ def toggle_alt():
     """TODO
 
     Audacity Documentation: Toggle focus on current track."""
-    return do('ToggleAlt')
+    return do("ToggleAlt")
 
 
 def cursor_left():
@@ -3391,7 +3842,7 @@ def cursor_left():
 
     Audacity Documentation: When not playing audio, moves the editing cursor one screen pixel to left. When a Snap To option is chosen, moves the cursor to the preceding unit of time as determined by the current selection format. If the key is held down, the cursor speed depends on the length of the tracks. When playing audio, moves the playback cursor as described at "Cursor Short Jump Left".
     """
-    return do('CursorLeft')
+    return do("CursorLeft")
 
 
 def cursor_right():
@@ -3400,7 +3851,7 @@ def cursor_right():
 
     Audacity Documentation: When not playing audio, moves the editing cursor one screen pixel to right. When a Snap To option is chosen, moves the cursor to the following unit of time as determined by the current selection format. If the key is held down, the cursor speed depends on the length of the tracks. When playing audio, moves the playback cursor as described at "Cursor Short Jump Right".
     """
-    return do('CursorRight')
+    return do("CursorRight")
 
 
 def cursor_short_jump_left():
@@ -3409,7 +3860,7 @@ def cursor_short_jump_left():
 
     Audacity Documentation: When not playing audio, moves the editing cursor one second left by default. When playing audio, moves the playback cursor one second left by default. The default value can be changed by adjusting the "Short Period" under "Seek Time when playing" in Playback Preferences.
     """
-    return do('CursorShortJumpLeft')
+    return do("CursorShortJumpLeft")
 
 
 def cursor_short_jump_right():
@@ -3418,7 +3869,7 @@ def cursor_short_jump_right():
 
     Audacity Documentation: When not playing audio, moves the editing cursor one second right by default. When playing audio, moves the playback cursor one second right by default. The default value can be changed by adjusting the "Short Period" under "Seek Time when playing" in Playback Preferences.
     """
-    return do('CursorShortJumpRight')
+    return do("CursorShortJumpRight")
 
 
 def cursor_long_jump_left():
@@ -3427,7 +3878,7 @@ def cursor_long_jump_left():
 
     Audacity Documentation: When not playing audio, moves the editing cursor 15 seconds left by default. When playing audio, moves the playback cursor 15 seconds left by default. The default value can be changed by adjusting the "Long Period" under "Seek Time when playing" in Playback Preferences.
     """
-    return do('CursorLongJumpLeft')
+    return do("CursorLongJumpLeft")
 
 
 def cursor_long_jump_right():
@@ -3436,7 +3887,7 @@ def cursor_long_jump_right():
 
     Audacity Documentation: When not playing audio, moves the editing cursor 15 seconds right by default. When playing audio, moves the playback cursor 15 seconds right by default. The default value can be changed by adjusting the "Long Period" under "Seek Time when playing" in Playback Preferences.
     """
-    return do('CursorLongJumpRight')
+    return do("CursorLongJumpRight")
 
 
 def clip_left():
@@ -3445,7 +3896,7 @@ def clip_left():
 
     Audacity Documentation: Moves the currently focused audio track (or a separate clip in that track which contains the editing cursor or selection region) one screen pixel to left.
     """
-    return do('ClipLeft')
+    return do("ClipLeft")
 
 
 def clip_right():
@@ -3454,7 +3905,7 @@ def clip_right():
 
     Audacity Documentation: Moves the currently focused audio track (or a separate clip in that track which contains the editing cursor or selection region) one screen pixel to right.
     """
-    return do('ClipRight')
+    return do("ClipRight")
 
 
 def track_pan():
@@ -3463,7 +3914,7 @@ def track_pan():
 
     Audacity Documentation: Brings up the Pan dialog for the focused track where you can enter a pan value, or use the slider for finer control of panning than is available when using the track pan slider.
     """
-    return do('TrackPan')
+    return do("TrackPan")
 
 
 def track_pan_left():
@@ -3472,7 +3923,7 @@ def track_pan_left():
 
     Audacity Documentation: Controls the pan slider on the focused track. Each keypress changes the pan value by 10% left.
     """
-    return do('TrackPanLeft')
+    return do("TrackPanLeft")
 
 
 def track_pan_right():
@@ -3481,7 +3932,7 @@ def track_pan_right():
 
     Audacity Documentation: Controls the pan slider on the focused track. Each keypress changes the pan value by 10% right.
     """
-    return do('TrackPanRight')
+    return do("TrackPanRight")
 
 
 def track_gain():
@@ -3490,7 +3941,7 @@ def track_gain():
 
     Audacity Documentation: Brings up the Gain dialog for the focused track where you can enter a gain value, or use the slider for finer control of gain than is available when using the track pan slider.
     """
-    return do('TrackGain')
+    return do("TrackGain")
 
 
 def track_gain_inc():
@@ -3499,7 +3950,7 @@ def track_gain_inc():
 
     Audacity Documentation: Controls the gain slider on the focused track. Each keypress increases the gain value by 1 dB.
     """
-    return do('TrackGainInc')
+    return do("TrackGainInc")
 
 
 def track_gain_dec():
@@ -3508,7 +3959,7 @@ def track_gain_dec():
 
     Audacity Documentation: Controls the gain slider on the focused track. Each keypress decreases the gain value by 1 dB.
     """
-    return do('TrackGainDec')
+    return do("TrackGainDec")
 
 
 def track_menu():
@@ -3517,7 +3968,7 @@ def track_menu():
 
     Audacity Documentation: Opens the Audio Track Dropdown Menu on the focused audio track or other track type. In the audio track dropdown, use Up, and Down, arrow keys to navigate the menu and Enter, to select a menu item. Use Right, arrow to open the "Set Sample Format" and "Set Rate" choices or Left, arrow to leave those choices.
     """
-    return do('TrackMenu')
+    return do("TrackMenu")
 
 
 def track_mute():
@@ -3525,7 +3976,7 @@ def track_mute():
     """TODO
 
     Audacity Documentation: Toggles the Mute button on the focused track."""
-    return do('TrackMute')
+    return do("TrackMute")
 
 
 def track_solo():
@@ -3533,7 +3984,7 @@ def track_solo():
     """TODO
 
     Audacity Documentation: Toggles the Solo button on the focused track."""
-    return do('TrackSolo')
+    return do("TrackSolo")
 
 
 def track_close():
@@ -3541,39 +3992,43 @@ def track_close():
     """TODO
 
     Audacity Documentation: Close (remove) the focused track only."""
-    return do('TrackClose')
+    return do("TrackClose")
 
 
 def track_move_up():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Moves the focused track up by one track and moves the focus there."""
-    return do('TrackMoveUp')
+    Audacity Documentation: Moves the focused track up by one track and moves the focus there.
+    """
+    return do("TrackMoveUp")
 
 
 def track_move_down():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Moves the focused track down by one track and moves the focus there."""
-    return do('TrackMoveDown')
+    Audacity Documentation: Moves the focused track down by one track and moves the focus there.
+    """
+    return do("TrackMoveDown")
 
 
 def track_move_top():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Moves the focused track up to the top of the track table and moves the focus there."""
-    return do('TrackMoveTop')
+    Audacity Documentation: Moves the focused track up to the top of the track table and moves the focus there.
+    """
+    return do("TrackMoveTop")
 
 
 def track_move_bottom():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Moves the focused track down to the bottom of the track table and moves the focus there."""
-    return do('TrackMoveBottom')
+    Audacity Documentation: Moves the focused track down to the bottom of the track table and moves the focus there.
+    """
+    return do("TrackMoveBottom")
 
 
 def select_time(start=None, end=None, relative_to=None):
@@ -3584,11 +4039,17 @@ def select_time(start=None, end=None, relative_to=None):
     """
 
     if not isinstance(start, (type(None), float, int)):
-        raise PyAudacityException('start argument must be float or int, not ' + str(type(start)))
+        raise PyAudacityException(
+            "start argument must be float or int, not " + str(type(start))
+        )
     if not isinstance(end, (type(None), float, int)):
-        raise PyAudacityException('end argument must be float or int, not ' + str(type(end)))
+        raise PyAudacityException(
+            "end argument must be float or int, not " + str(type(end))
+        )
     if not isinstance(relative_to, (type(None), str)):
-        raise PyAudacityException('relative_to argument must be str, not ' + str(type(relative_to)))
+        raise PyAudacityException(
+            "relative_to argument must be str, not " + str(type(relative_to))
+        )
 
     # TODO check relative_to argument
 
@@ -3601,19 +4062,24 @@ def select_time(start=None, end=None, relative_to=None):
     if relative_to is not None:
         macro_arguments.append('RelativeTo="{}"'.format(relative_to))
 
-    return do('SelectTime: ' + ' '.join(macro_arguments))
+    return do("SelectTime: " + " ".join(macro_arguments))
 
 
 def select_frequencies(high=None, low=None):
     # type: (Optional[float], Optional[float]) -> str
     """TODO
 
-    Audacity Documentation: Modifies what frequencies are selected. High and Low are for spectral selection."""
+    Audacity Documentation: Modifies what frequencies are selected. High and Low are for spectral selection.
+    """
 
     if not isinstance(high, (type(None), float, int)):
-        raise PyAudacityException('high argument must be float or int, not ' + str(type(high)))
+        raise PyAudacityException(
+            "high argument must be float or int, not " + str(type(high))
+        )
     if not isinstance(low, (type(None), float, int)):
-        raise PyAudacityException('low argument must be float or int, not ' + str(type(low)))
+        raise PyAudacityException(
+            "low argument must be float or int, not " + str(type(low))
+        )
 
     # Only include arguments if they are not None. (If they are none, then the selection is "unchanged" according to the documentation.)
     macro_arguments = []
@@ -3622,7 +4088,7 @@ def select_frequencies(high=None, low=None):
     if low is not None:
         macro_arguments.append('Low="{}"'.format(low))
 
-    return do('SelectFrequencies: ' + ' '.join(macro_arguments))
+    return do("SelectFrequencies: " + " ".join(macro_arguments))
 
 
 def select_tracks():
@@ -3644,7 +4110,8 @@ def set_track_status():
 def set_track_audio():
     """TODO
 
-    Audacity Documentation: Sets properties for a track or channel (or both). Can set pan, gain, mute and solo."""
+    Audacity Documentation: Sets properties for a track or channel (or both). Can set pan, gain, mute and solo.
+    """
     raise NotImplementedError
 
 
@@ -3690,7 +4157,8 @@ def set_envelope():
 def set_label():
     """TODO
 
-    Audacity Documentation: Modifies an existing label. You must give it the label number."""
+    Audacity Documentation: Modifies an existing label. You must give it the label number.
+    """
     raise NotImplementedError
 
 
@@ -3718,31 +4186,48 @@ def set_track():
     raise NotImplementedError
 
 
-def get_info(info_type='Commands', format='JSON'):
+def get_info(info_type="Commands", format="JSON"):
     # type: (str, str) -> str
     """TODO
 
     Audacity Documentation: Gets information in a list in one of three formats."""
 
-    if info_type.title() not in ('Commands', 'Menus', 'Preferences', 'Tracks', 'Clips', 'Envelopes', 'Labels', 'Boxes'):
+    if info_type.title() not in (
+        "Commands",
+        "Menus",
+        "Preferences",
+        "Tracks",
+        "Clips",
+        "Envelopes",
+        "Labels",
+        "Boxes",
+    ):
         raise PyAudacityException(
             'info_type argument must be one of "Commands", "Menus", "Preferences", "Tracks", "Clips", "Envelopes", "Labels", or "Boxes"'
         )
-    formats = 'JSON LISP Brief'.split()
+    formats = "JSON LISP Brief".split()
     if format not in formats:
-        raise PyAudacityException('format argument must be one of' + ', '.join([ '"' + f + '"' for f in  formats[:-1]]) + ', and "' + formats[-1] + '"')
+        raise PyAudacityException(
+            "format argument must be one of"
+            + ", ".join(['"' + f + '"' for f in formats[:-1]])
+            + ', and "'
+            + formats[-1]
+            + '"'
+        )
 
     return do('GetInfo: Type="{}" Format="{}"'.format(info_type, format))
 
 
-def message(text='Some message'):
+def message(text="Some message"):
     # type: (str) -> str
     """TODO
 
     Audacity Documentation: Used in testing. Sends the Text string back to you."""
 
     if not isinstance(text, str):
-        raise PyAudacityException('message argument must be str, not ' + str(type(text)))
+        raise PyAudacityException(
+            "message argument must be str, not " + str(type(text))
+        )
 
     return do('Message: Text="{}"'.format(text))
 
@@ -3750,7 +4235,8 @@ def message(text='Some message'):
 def help():
     """TODO
 
-    Audacity Documentation: This is an extract from GetInfo Commands, with just one command."""
+    Audacity Documentation: This is an extract from GetInfo Commands, with just one command.
+    """
     raise NotImplementedError
 
 
@@ -3786,7 +4272,8 @@ def drag():
 def compare_audio():
     """TODO
 
-    Audacity Documentation: Compares selected range on two tracks. Reports on the differences and similarities."""
+    Audacity Documentation: Compares selected range on two tracks. Reports on the differences and similarities.
+    """
     raise NotImplementedError
 
 
@@ -3794,8 +4281,9 @@ def quick_help():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: A brief version of help with some of the most essential information."""
-    return do('QuickHelp')
+    Audacity Documentation: A brief version of help with some of the most essential information.
+    """
+    return do("QuickHelp")
 
 
 def manual():
@@ -3803,15 +4291,16 @@ def manual():
     """TODO
 
     Audacity Documentation: Opens the manual in the default browser."""
-    return do('Manual')
+    return do("Manual")
 
 
 def updates():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Checks online to see if this is the latest version of Audacity."""
-    return do('Updates')
+    Audacity Documentation: Checks online to see if this is the latest version of Audacity.
+    """
+    return do("Updates")
 
 
 def about():
@@ -3820,23 +4309,25 @@ def about():
 
     Audacity Documentation: Brings a dialog with information about Audacity, such as who wrote it, what features are enabled and the GNU GPL v2 license.
     """
-    return do('About')
+    return do("About")
 
 
 def device_info():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Shows technical information about your detected audio device(s)."""
-    return do('DeviceInfo')
+    Audacity Documentation: Shows technical information about your detected audio device(s).
+    """
+    return do("DeviceInfo")
 
 
 def midi_device_info():
     # type: () -> str
     """TODO
 
-    Audacity Documentation: Shows technical information about your detected MIDI device(s)."""
-    return do('MidiDeviceInfo')
+    Audacity Documentation: Shows technical information about your detected MIDI device(s).
+    """
+    return do("MidiDeviceInfo")
 
 
 def log():
@@ -3845,7 +4336,7 @@ def log():
 
     Audacity Documentation: Launches the "Audacity Log" window, the log is largely a debugging aid, having timestamps for each entry.
     """
-    return do('Log')
+    return do("Log")
 
 
 def crash_report():
@@ -3854,7 +4345,7 @@ def crash_report():
 
     Audacity Documentation: Selecting this will generate a Debug report which could be useful in aiding the developers to identify bugs in Audacity or in third-party plugins.
     """
-    return do('CrashReport')
+    return do("CrashReport")
 
 
 def check_deps():
@@ -3863,7 +4354,7 @@ def check_deps():
 
     Audacity Documentation: Lists any WAV or AIFF audio files that your project depends on, and allows you to copy these files into the project.
     """
-    return do('CheckDeps')
+    return do("CheckDeps")
 
 
 def prev_window():
@@ -3871,7 +4362,7 @@ def prev_window():
     """TODO
 
     Audacity Documentation: Navigates to the previous window."""
-    return do('PrevWindow')
+    return do("PrevWindow")
 
 
 def next_window():
@@ -3879,4 +4370,4 @@ def next_window():
     """TODO
 
     Audacity Documentation: Navigates to the next window."""
-    return do('NextWindow')
+    return do("NextWindow")

--- a/src/pyaudacity/__init__.py
+++ b/src/pyaudacity/__init__.py
@@ -3728,7 +3728,7 @@ def get_info(info_type='Commands', format='JSON'):
         raise PyAudacityException(
             'info_type argument must be one of "Commands", "Menus", "Preferences", "Tracks", "Clips", "Envelopes", "Labels", or "Boxes"'
         )
-    if format.title() not in ('JSON', 'LISP', 'Brief'):
+    if format not in ('JSON', 'LISP', 'Brief'):
         raise PyAudacityException('format argument must be one of "JSON", "LISP", or "Brief"')
 
     return do('GetInfo: Type="{}" Format="{}"'.format(info_type, format))

--- a/src/pyaudacity/__init__.py
+++ b/src/pyaudacity/__init__.py
@@ -2093,7 +2093,11 @@ def bass_and_treble(bass=0, treble=0, gain=0, link_sliders=False):
 
     # TODO - The documentation shows it as "Link Sliders" but I don't know if the space is intentional or not.
     # There's no way to tell since Audacity's macro system doesn't give errors for bad parameter names.
-    return do('BassAndTreble: Bass="{}" Treble="{}" Gain="{}" LinkSliders="{}"'.format(bass, treble, gain, link_sliders))
+    return do(
+        'BassAndTreble: Bass="{}" Treble="{}" Gain="{}" LinkSliders="{}"'.format(
+            bass, treble, gain, link_sliders
+        )
+    )
 
 
 def change_pitch(percentage=0.0, use_high_quality_stretching=False):
@@ -2668,7 +2672,9 @@ def truncate_silence(
         )
 
     return do(
-        'TruncateSilence: Threshold="{}" Action="{}" Minimum="{}" Truncate="{}" Compress="{}" Independent="{}"'.format(threshold, action, minimum, truncate, compress, independent)
+        'TruncateSilence: Threshold="{}" Action="{}" Minimum="{}" Truncate="{}" Compress="{}" Independent="{}"'.format(
+            threshold, action, minimum, truncate, compress, independent
+        )
     )
 
 
@@ -2703,7 +2709,9 @@ def wahwah(freq=1.5, phase=0.0, depth=70, resonance=2.5, offset=30, gain=-6.0):
         )
 
     return do(
-        'Wahwah: Freq="{}" Phase="{}" Depth="{}" Resonance="{}" Offset="{}" Gain="{}"'.format(freq, phase, depth, resonance, offset, gain)
+        'Wahwah: Freq="{}" Phase="{}" Depth="{}" Resonance="{}" Offset="{}" Gain="{}"'.format(
+            freq, phase, depth, resonance, offset, gain
+        )
     )
 
 
@@ -2922,7 +2930,9 @@ def tremolo(wave="Sine", phase=0, wet=0, lfo=0.0):
             "lfo argument must be float or int, not " + str(type(lfo))
         )
 
-    return do('Tremolo: wave="{}" phase="{}" wet="{}" lfo="{}"'.format(wave, phase, wet, lfo))
+    return do(
+        'Tremolo: wave="{}" phase="{}" wet="{}" lfo="{}"'.format(wave, phase, wet, lfo)
+    )
 
 
 def vocal_reduction_and_isolation(
@@ -2951,7 +2961,11 @@ def vocal_reduction_and_isolation(
             + str(type(high_transition))
         )
 
-    return do('TODO: strength="{}" low_transition="{}" high_transition="{}"'.format(strength, low_transition, high_transition))
+    return do(
+        'TODO: strength="{}" low_transition="{}" high_transition="{}"'.format(
+            strength, low_transition, high_transition
+        )
+    )
 
 
 def vocoder(
@@ -2994,7 +3008,9 @@ def vocoder(
         )
 
     return do(
-        'TODO: dst="{}" mst="{}" bands="{}" track-vl="{}" noise-vl="{}" radar-vl="{}" radar-f="{}"'.format(dst, mst, bands, track_vl, noise_vl, radar_vl, radar_f)
+        'TODO: dst="{}" mst="{}" bands="{}" track-vl="{}" noise-vl="{}" radar-vl="{}" radar-f="{}"'.format(
+            dst, mst, bands, track_vl, noise_vl, radar_vl, radar_f
+        )
     )
 
 
@@ -3045,7 +3061,11 @@ def find_clipping(duty_cycle_start=3, duty_cycle_end=3):
             "duty_cycle_end argument must be int, not " + str(type(duty_cycle_end))
         )
 
-    return do('FindClipping: DutyCycleStart="{}" DutyCycleEnd="{}"'.format(duty_cycle_start, duty_cycle_end))
+    return do(
+        'FindClipping: DutyCycleStart="{}" DutyCycleEnd="{}"'.format(
+            duty_cycle_start, duty_cycle_end
+        )
+    )
 
 
 def beat_finder(thresval=0):
@@ -3211,16 +3231,16 @@ def regular_interval_labels(
 
     return do(
         'RegularIntervalLabels: mode="{}" totalnum="{}" interval="{}" region="{}" adjust="{}" labeltext="{}" zeros="{}" firstnum="{}" verbose="{}"'.format(
-        mode,
-        total_num,
-        interval,
-        region,
-        adjust,
-        label_text,
-        zeros,
-        first_number,
-        verbose,
-    )
+            mode,
+            total_num,
+            interval,
+            region,
+            adjust,
+            label_text,
+            zeros,
+            first_number,
+            verbose,
+        )
     )
 
 

--- a/src/pyaudacity/__init__.py
+++ b/src/pyaudacity/__init__.py
@@ -2620,14 +2620,14 @@ def sliding_stretch(
         )
 
     return do(
-        'TODO: RatePercentChangeStart="{}" RatePercentChangeEnd="{}" PitchHalfStepsStart="{}" PitchHalfStepsEnd="{}" PitchPercentChangeStart="{}" PitchPercentChangeEnd="{}"'
-    ).format(
-        rate_percent_change_start,
-        rate_percent_change_end,
-        pitch_half_steps_start,
-        pitch_half_steps_end,
-        pitch_percent_change_start,
-        pitch_percent_change_end,
+        'TODO: RatePercentChangeStart="{}" RatePercentChangeEnd="{}" PitchHalfStepsStart="{}" PitchHalfStepsEnd="{}" PitchPercentChangeStart="{}" PitchPercentChangeEnd="{}"'.format(
+            rate_percent_change_start,
+            rate_percent_change_end,
+            pitch_half_steps_start,
+            pitch_half_steps_end,
+            pitch_percent_change_start,
+            pitch_percent_change_end,
+        )
     )
 
 
@@ -2668,8 +2668,8 @@ def truncate_silence(
         )
 
     return do(
-        'TruncateSilence: Threshold="{}" Action="{}" Minimum="{}" Truncate="{}" Compress="{}" Independent="{}"'
-    ).format(threshold, action, minimum, truncate, compress, independent)
+        'TruncateSilence: Threshold="{}" Action="{}" Minimum="{}" Truncate="{}" Compress="{}" Independent="{}"'.format(threshold, action, minimum, truncate, compress, independent)
+    )
 
 
 def wahwah(freq=1.5, phase=0.0, depth=70, resonance=2.5, offset=30, gain=-6.0):
@@ -2703,8 +2703,8 @@ def wahwah(freq=1.5, phase=0.0, depth=70, resonance=2.5, offset=30, gain=-6.0):
         )
 
     return do(
-        'Wahwah: Freq="{}" Phase="{}" Depth="{}" Resonance="{}" Offset="{}" Gain="{}"'
-    ).format(freq, phase, depth, resonance, offset, gain)
+        'Wahwah: Freq="{}" Phase="{}" Depth="{}" Resonance="{}" Offset="{}" Gain="{}"'.format(freq, phase, depth, resonance, offset, gain)
+    )
 
 
 def adjustable_fade(
@@ -2847,7 +2847,7 @@ def notch_filter(frequency=0.0, q=0.0):
             "q argument must be float or int, not " + str(type(q))
         )
 
-    return do('NotchFilter: frequency="{}" q="{}"').format(frequency, q)
+    return do('NotchFilter: frequency="{}" q="{}"'.format(frequency, q))
 
 
 def spectral_edit_multi_tool():
@@ -2872,7 +2872,7 @@ def spectral_edit_parametric_eq(control_gain=0.0):
         )
 
     # TODO - double check other macros for parameter names with dashes.
-    return do('SpectralEditParametricEq: control-gain="{}"').format(control_gain)
+    return do('SpectralEditParametricEq: control-gain="{}"'.format(control_gain))
 
 
 def spectral_edit_shelves(control_gain=0.0):
@@ -2887,7 +2887,7 @@ def spectral_edit_shelves(control_gain=0.0):
             "control_gain argument must be float or int, not " + str(type(control_gain))
         )
 
-    return do('SpectralEditShelves: control-gain="{}"').format(control_gain)
+    return do('SpectralEditShelves: control-gain="{}"'.format(control_gain))
 
 
 def studio_fade_out():
@@ -2922,9 +2922,7 @@ def tremolo(wave="Sine", phase=0, wet=0, lfo=0.0):
             "lfo argument must be float or int, not " + str(type(lfo))
         )
 
-    return do('Tremolo: wave="{}" phase="{}" wet="{}" lfo="{}"').format(
-        wave, phase, wet, lfo
-    )
+    return do('Tremolo: wave="{}" phase="{}" wet="{}" lfo="{}"'.format(wave, phase, wet, lfo))
 
 
 def vocal_reduction_and_isolation(
@@ -2953,9 +2951,7 @@ def vocal_reduction_and_isolation(
             + str(type(high_transition))
         )
 
-    return do('TODO: strength="{}" low_transition="{}" high_transition="{}"').format(
-        strength, low_transition, high_transition
-    )
+    return do('TODO: strength="{}" low_transition="{}" high_transition="{}"'.format(strength, low_transition, high_transition))
 
 
 def vocoder(
@@ -2998,8 +2994,8 @@ def vocoder(
         )
 
     return do(
-        'TODO: dst="{}" mst="{}" bands="{}" track-vl="{}" noise-vl="{}" radar-vl="{}" radar-f="{}"'
-    ).format(dst, mst, bands, track_vl, noise_vl, radar_vl, radar_f)
+        'TODO: dst="{}" mst="{}" bands="{}" track-vl="{}" noise-vl="{}" radar-vl="{}" radar-f="{}"'.format(dst, mst, bands, track_vl, noise_vl, radar_vl, radar_f)
+    )
 
 
 # NOTE THE SPELLING OF "ANALYZERS"
@@ -3049,9 +3045,7 @@ def find_clipping(duty_cycle_start=3, duty_cycle_end=3):
             "duty_cycle_end argument must be int, not " + str(type(duty_cycle_end))
         )
 
-    return do('FindClipping: DutyCycleStart="{}" DutyCycleEnd="{}"').format(
-        duty_cycle_start, duty_cycle_end
-    )
+    return do('FindClipping: DutyCycleStart="{}" DutyCycleEnd="{}"'.format(duty_cycle_start, duty_cycle_end))
 
 
 def beat_finder(thresval=0):
@@ -3169,7 +3163,7 @@ def nyquist_prompt(command="", version=3):
             "version argument must be int, not " + str(type(version))
         )
 
-    return do('NyquistPrompt: Command="{}" Version="{}"').format(command, version)
+    return do('NyquistPrompt: Command="{}" Version="{}"'.format(command, version))
 
 
 def nyquist_plugin_installer(files="", overwrite="Disallow"):
@@ -3216,8 +3210,7 @@ def regular_interval_labels(
         )
 
     return do(
-        'RegularIntervalLabels: mode="{}" totalnum="{}" interval="{}" region="{}" adjust="{}" labeltext="{}" zeros="{}" firstnum="{}" verbose="{}"'
-    ).format(
+        'RegularIntervalLabels: mode="{}" totalnum="{}" interval="{}" region="{}" adjust="{}" labeltext="{}" zeros="{}" firstnum="{}" verbose="{}"'.format(
         mode,
         total_num,
         interval,
@@ -3227,6 +3220,7 @@ def regular_interval_labels(
         zeros,
         first_number,
         verbose,
+    )
     )
 
 

--- a/src/pyaudacity/__init__.py
+++ b/src/pyaudacity/__init__.py
@@ -3066,7 +3066,7 @@ def beat_finder(thresval=0):
             "thresval argument must be int, not " + str(type(thresval))
         )
 
-    return do('BeatFinder: thresval="{}"').format(thresval)
+    return do('BeatFinder: thresval="{}"'.format(thresval))
 
 
 def label_sounds(

--- a/src/pyaudacity/__init__.py
+++ b/src/pyaudacity/__init__.py
@@ -2624,7 +2624,7 @@ def sliding_stretch(
         )
 
     return do(
-        'TODO: RatePercentChangeStart="{}" RatePercentChangeEnd="{}" PitchHalfStepsStart="{}" PitchHalfStepsEnd="{}" PitchPercentChangeStart="{}" PitchPercentChangeEnd="{}"'.format(
+        'SlidingStretch: RatePercentChangeStart="{}" RatePercentChangeEnd="{}" PitchHalfStepsStart="{}" PitchHalfStepsEnd="{}" PitchPercentChangeStart="{}" PitchPercentChangeEnd="{}"'.format(
             rate_percent_change_start,
             rate_percent_change_end,
             pitch_half_steps_start,

--- a/src/pyaudacity/__init__.py
+++ b/src/pyaudacity/__init__.py
@@ -61,6 +61,7 @@ from typing import Union, Optional
 _open = open
 _type = type
 _format = format
+_print = print
 
 
 class PyAudacityException(Exception):

--- a/src/pyaudacity/__init__.py
+++ b/src/pyaudacity/__init__.py
@@ -3728,8 +3728,9 @@ def get_info(info_type='Commands', format='JSON'):
         raise PyAudacityException(
             'info_type argument must be one of "Commands", "Menus", "Preferences", "Tracks", "Clips", "Envelopes", "Labels", or "Boxes"'
         )
-    if format not in ('JSON', 'LISP', 'Brief'):
-        raise PyAudacityException('format argument must be one of "JSON", "LISP", or "Brief"')
+    formats = 'JSON LISP Brief'.split()
+    if format not in formats:
+        raise PyAudacityException('format argument must be one of' + ', '.join([ '"' + f + '"' for f in  formats[:-1]]) + ', and "' + formats[-1] + '"')
 
     return do('GetInfo: Type="{}" Format="{}"'.format(info_type, format))
 

--- a/src/pyaudacity/__init__.py
+++ b/src/pyaudacity/__init__.py
@@ -2996,7 +2996,19 @@ def vocoder(
         raise PyAudacityException(
             "dst argument must be float or int, not " + str(type(dst))
         )
-    # TODO check mst
+
+    msts = "BothChannels RightOnly".split()
+
+
+    if mst not in msts:
+        raise PyAudacityException(
+            "mst must be one of "
+            + ", ".join(msts)
+            + ", but was: '"
+            + mst
+            + "'."
+        )
+
     if not isinstance(bands, int):
         raise PyAudacityException("bands argument must be int, not " + str(type(bands)))
     if not isinstance(track_vl, (float, int)):
@@ -3017,7 +3029,7 @@ def vocoder(
         )
 
     return do(
-        'TODO: dst="{}" mst="{}" bands="{}" track-vl="{}" noise-vl="{}" radar-vl="{}" radar-f="{}"'.format(
+        'Vocoder: dst="{}" mst="{}" bands="{}" track-vl="{}" noise-vl="{}" radar-vl="{}" radar-f="{}"'.format(
             dst, mst, bands, track_vl, noise_vl, radar_vl, radar_f
         )
     )

--- a/src/pyaudacity/__init__.py
+++ b/src/pyaudacity/__init__.py
@@ -342,7 +342,7 @@ def import_audio(filename):
     if not os.path.exists(filename):
         raise PyAudacityException(str(filename) + " file not found.")
 
-    return do("ImportAudio")
+    return do(f'Import2: Filename="{filename}"')
 
 
 def import_labels():


### PR DESCRIPTION
FIXES: several `format` calls were wrongly applied to the **_result_** of `do` instead of its **_parameter string_**

Example `TruncateSilence` was:
```Python
    return do(
        'TruncateSilence: Threshold="{}" Action="{}" Minimum="{}" Truncate="{}" Compress="{}" Independent="{}"'
    ).format(threshold, action, minimum, truncate, compress, independent)
```
fixed:
```Python
    return do(
        'TruncateSilence: Threshold="{}" Action="{}" Minimum="{}" Truncate="{}" Compress="{}" Independent="{}"'.format(
            threshold, action, minimum, truncate, compress, independent
        )
```

@trjh's PR has been applied "add progressive fallback wait for audacity pipes to be ready"